### PR TITLE
Add `SecureKeys` xcframework automatically from CLI

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -12,15 +12,23 @@ PATH
       optparse (~> 0.6.0)
       osx_keychain (~> 1.0.2)
       tty-screen (~> 0.8.2)
+      xcodeproj (~> 1.27.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
+    CFPropertyList (3.0.7)
+      base64
+      nkf
+      rexml
     RubyInline (3.14.1)
       ZenTest (~> 4.3)
     ZenTest (4.12.2)
     ast (2.4.2)
+    atomos (0.1.3)
     base64 (0.2.0)
+    claide (1.1.0)
+    colored2 (3.1.2)
     colorize (1.1.0)
     diff-lcs (1.6.0)
     digest (3.2.0)
@@ -29,6 +37,8 @@ GEM
     json (2.10.1)
     language_server-protocol (3.17.0.4)
     logger (1.6.6)
+    nanaimo (0.4.0)
+    nkf (0.2.0)
     open3 (0.2.1)
     optparse (0.6.0)
     osx_keychain (1.0.2)
@@ -41,6 +51,7 @@ GEM
     rainbow (3.1.1)
     rake (13.2.1)
     regexp_parser (2.10.0)
+    rexml (3.4.1)
     rspec (3.13.0)
       rspec-core (~> 3.13.0)
       rspec-expectations (~> 3.13.0)
@@ -79,6 +90,13 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    xcodeproj (1.27.0)
+      CFPropertyList (>= 2.3.3, < 4.0)
+      atomos (~> 0.1.3)
+      claide (>= 1.0.2, < 2.0)
+      colored2 (~> 3.1)
+      nanaimo (~> 0.4.0)
+      rexml (>= 3.3.6, < 4.0)
 
 PLATFORMS
   arm64-darwin-23

--- a/README.md
+++ b/README.md
@@ -137,11 +137,13 @@ secure-keys --help
 
 Usage: secure-keys [--options]
 
-    -h, --help                       Use the provided commands to select the params
-    -d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")
-    -i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")
-        --verbose                    Enable verbose mode (default: false)
-    -v, --version                    Show the secure-keys version
+    -h, --help                                  Use the provided commands to select the params
+        --add-xcframework-to-target TARGET      Add the xcframework to the target
+    -d, --delimiter DELIMITER                   The delimiter to use for the key access (default: ",")
+    -i, --identifier IDENTIFIER                 The identifier to use for the key access (default: "secure-keys")
+        --verbose                               Enable verbose mode (default: false)
+    -v, --version                               Show the secure-keys version
+    -x, --xcodeproj XCODEPROJ                   The Xcode project path (default: the first found Xcode project)
 ```
 
 To avoid defining the `SECURE_KEYS_IDENTIFIER` and `SECURE_KEYS_DELIMITER` env variables, you can use the `--identifier` and `--delimiter` options.
@@ -183,6 +185,27 @@ let apiKey: String = .key(for: .apiKey)
 ```
 
 ## How to install the `SecureKeys.xcframework` in the iOS project
+
+### Automatically
+
+From the `secure-keys` command, you can use the `--add-xcframework-to-target` option to add the `SecureKeys.xcframework` to the iOS project.
+
+```bash
+secure-keys --add-xcframework-to-target "YourTargetName"
+```
+
+Also, you can specify your Xcode project path using the `--xcodeproj` option.
+
+```bash
+secure-keys --add-xcframework-to-target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
+```
+
+> [!IMPORTANT]
+> By default, the xcodeproj path would be the first found Xcode project.
+
+This command will generate the `SecureKeys.xcframework` and add it to the iOS project.
+
+### Manually
 
 1. From the iOS project, click on the project target, select the `General` tab, and scroll down to the `Frameworks, Libraries, and Embedded Content` section.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,11 +133,13 @@ secure-keys --help
 
 Usage: secure-keys [--options]
 
-    -h, --help                       Use the provided commands to select the params
-    -d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")
-    -i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")
-        --verbose                    Enable verbose mode (default: false)
-    -v, --version                    Show the secure-keys version
+    -h, --help                                  Use the provided commands to select the params
+        --add-xcframework-to-target TARGET      Add the xcframework to the target
+    -d, --delimiter DELIMITER                   The delimiter to use for the key access (default: ",")
+    -i, --identifier IDENTIFIER                 The identifier to use for the key access (default: "secure-keys")
+        --verbose                               Enable verbose mode (default: false)
+    -v, --version                               Show the secure-keys version
+    -x, --xcodeproj XCODEPROJ                   The Xcode project path (default: the first found Xcode project)
 ```
 
 To avoid defining the `SECURE_KEYS_IDENTIFIER` and `SECURE_KEYS_DELIMITER` env variables, you can use the `--identifier` and `--delimiter` options.
@@ -153,6 +155,27 @@ secure-keys -i "your-keychain-or-env-variable-identifier" -d "|"
 ```
 
 ### Step 3: Integrate SecureKeys.xcframework into Your iOS Project
+
+#### Automatically
+
+From the `secure-keys` command, you can use the `--add-xcframework-to-target` option to add the `SecureKeys.xcframework` to the iOS project.
+
+```bash
+secure-keys --add-xcframework-to-target "YourTargetName"
+```
+
+Also, you can specify your Xcode project path using the `--xcodeproj` option.
+
+```bash
+secure-keys --add-xcframework-to-target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
+```
+
+> [!IMPORTANT]
+> By default, the xcodeproj path would be the first found Xcode project.
+
+This command will generate the `SecureKeys.xcframework` and add it to the iOS project.
+
+#### Manually
 
 1. From the iOS project, click on the project target, select the `General` tab, and scroll down to the `Frameworks, Libraries, and Embedded Content` section.
 

--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -11,7 +11,9 @@ module SecureKeys
           @arguments = {
             delimiter: nil,
             identifier: nil,
+            target: nil,
             verbose: false,
+            xcodeproj: nil,
           }
 
           # Fetch the argument value by key

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -28,6 +28,9 @@ module SecureKeys
               exit(0)
             end
 
+            on('--add-xcframework-to-target TARGET', String, 'Add the xcframework to the target') do |target|
+              Handler.arguments[:target] = target
+            end
             on('-d', '--delimiter DELIMITER', String, "The delimiter to use for the key access (default: \"#{Globals.default_key_delimiter}\")")
             on('-i', '--identifier IDENTIFIER', String, "The identifier to use for the key access (default: \"#{Globals.default_key_access_identifier}\")")
             on('--verbose', TrueClass, 'Enable verbose mode (default: false)')
@@ -36,6 +39,7 @@ module SecureKeys
               puts "secure-keys version: v#{SecureKeys::VERSION}"
               exit(0)
             end
+            on('-x', '--xcodeproj XCODEPROJ', String, 'The Xcode project path (default: the first found Xcode project)')
           end
         end
       end

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -37,6 +37,8 @@ module SecureKeys
     # Returns the Xcode project path
     # @return [String] Xcode project path
     def xcodeproj_path
+      Core::Console::Logger.important(message: Core::Console::Argument::Handler.fetch(key: :xcodeproj, default: Dir.glob('**/*.xcodeproj').first))
+
       Core::Console::Argument::Handler.fetch(key: :xcodeproj,
                                              default: Dir.glob('**/*.xcodeproj').first)
     end
@@ -44,6 +46,9 @@ module SecureKeys
     # Returns the secure keys XCFramework path
     # @return [String] secure keys XCFramework path
     def secure_keys_xcframework_path
+      Core::Console::Logger.important(message: Dir.pwd)
+      Core::Console::Logger.important(message: "#{Dir.pwd}/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}")
+      Core::Console::Logger.important(message: Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first)
       Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first
     end
 

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -1,6 +1,7 @@
 #!/usr/bin/env ruby
 
 require_relative '../console/arguments/handler'
+require_relative '../utils/swift/swift'
 
 module SecureKeys
   module Globals
@@ -44,7 +45,8 @@ module SecureKeys
     # Returns the secure keys XCFramework path
     # @return [String] secure keys XCFramework path
     def secure_keys_xcframework_path
-      Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first
+      Dir.glob(["**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}",
+                "../**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}"]).first
     end
 
     # Returns the supported iOS platforms

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -37,8 +37,6 @@ module SecureKeys
     # Returns the Xcode project path
     # @return [String] Xcode project path
     def xcodeproj_path
-      Core::Console::Logger.important(message: Core::Console::Argument::Handler.fetch(key: :xcodeproj, default: Dir.glob('**/*.xcodeproj').first))
-
       Core::Console::Argument::Handler.fetch(key: :xcodeproj,
                                              default: Dir.glob('**/*.xcodeproj').first)
     end
@@ -46,9 +44,6 @@ module SecureKeys
     # Returns the secure keys XCFramework path
     # @return [String] secure keys XCFramework path
     def secure_keys_xcframework_path
-      Core::Console::Logger.important(message: Dir.pwd)
-      Core::Console::Logger.important(message: "#{Dir.pwd}/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}")
-      Core::Console::Logger.important(message: Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first)
       Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first
     end
 

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -45,8 +45,7 @@ module SecureKeys
     # Returns the secure keys XCFramework path
     # @return [String] secure keys XCFramework path
     def secure_keys_xcframework_path
-      Dir.glob(["**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}",
-                "../**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}"]).first
+      Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first
     end
 
     # Returns the supported iOS platforms

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -41,6 +41,12 @@ module SecureKeys
                                              default: Dir.glob('**/*.xcodeproj').first)
     end
 
+    # Returns the secure keys XCFramework path
+    # @return [String] secure keys XCFramework path
+    def secure_keys_xcframework_path
+      Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first
+    end
+
     # Returns the supported iOS platforms
     # @return [Array] supported iOS platforms
     def ios_platforms

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -34,6 +34,13 @@ module SecureKeys
                                       .eql?('true')
     end
 
+    # Returns the Xcode project path
+    # @return [String] Xcode project path
+    def xcodeproj_path
+      Core::Console::Argument::Handler.fetch(key: :xcodeproj,
+                                             default: Dir.glob('**/*.xcodeproj').first)
+    end
+
     # Returns the supported iOS platforms
     # @return [Array] supported iOS platforms
     def ios_platforms

--- a/lib/core/utils/swift/xcframework.rb
+++ b/lib/core/utils/swift/xcframework.rb
@@ -89,7 +89,6 @@ module SecureKeys
         return if target_name.to_s.empty?
 
         Core::Console::Logger.important(message: "Adding the XCFramework to the target '#{target_name}'")
-
         xcodeproj = Xcodeproj.xcodeproj
         xcodeproj_target = Xcodeproj.xcodeproj_target_by_target_name(xcodeproj:, target_name:)
         Xcodeproj.add_framework_search_path(xcodeproj_target:)

--- a/lib/core/utils/swift/xcframework.rb
+++ b/lib/core/utils/swift/xcframework.rb
@@ -1,8 +1,11 @@
 #!/usr/bin/env ruby
 
+require 'xcodeproj'
 require_relative './swift'
 require_relative '../../globals/globals'
 require_relative '../../console/shell'
+require_relative '../../console/logger'
+require_relative '../../console/arguments/handler'
 
 module SecureKeys
   module Swift
@@ -13,12 +16,13 @@ module SecureKeys
         # Currently this is failling with the following error:
         # "library with the identifier 'ios-arm64' already exists."
         %w[Release].each do |configuration|
-          SecureKeys::Globals.ios_platforms.each do |platform|
+          Globals.ios_platforms.each do |platform|
             generate_key_modules(configuration:, platform:)
             generate_key_libraries(configuration:, platform: platform[:path])
           end
         end
         generate_key_xcframework
+        add_xcframework_to_xcodeproj_target_if_needed
       end
 
       private
@@ -76,6 +80,41 @@ module SecureKeys
             "-library #{BUILD_DIRECTORY}/#{configuration}-#{platform[:path]}/lib#{SWIFT_PACKAGE_NAME}.a"
           end.join(' ')
         end.join(' ')
+      end
+
+      # Add the XCFramework to the Xcode project target if needed
+      # @param target_name [String] The target name to add the XCFramework
+      def add_xcframework_to_xcodeproj_target_if_needed(target_name: nil)
+        target_name ||= Core::Console::Argument::Handler.fetch(key: :target)
+
+        return if target_name.to_s.empty?
+
+        xcodeproj = Xcodeproj::Project.open(SecureKeys::Globals.xcodeproj_path)
+        return Core::Console::Logger.error(message: "The xcodeproj #{xcodeproj} already have the #{XCFRAMEWORK_DIRECTORY}") if xcodeproj_has_secure_keys_xcframework?(xcodeproj:)
+
+        Core::Console::Logger.important(message: "Adding the XCFramework to the target '#{target_name}'")
+        xcodeproj_target = xcodeproj.targets.find { |target| target.name.eql?(target_name) }
+
+        Core::Console::Logger.crash!(message: "The target #{target_name} was not found") if xcodeproj_target.nil?
+
+        xcframework_ref = xcodeproj.frameworks_group.new_file(XCFRAMEWORK_DIRECTORY)
+        xcodeproj_target.frameworks_build_phase.add_file_reference(xcframework_ref)
+
+        xcodeproj.save
+      end
+
+      # Check if the Xcode project has the secure keys XCFramework
+      # @param xcodeproj [Xcodeproj::Project] The Xcode project
+      # @return [Bool] true if the Xcode project has the secure keys XCFramework
+      def xcodeproj_has_secure_keys_xcframework?(xcodeproj:)
+        xcodeproj.targets.each do |target|
+          target.frameworks_build_phase.files.each do |file|
+            next if file.file_ref.nil?
+
+            return true if file.file_ref.path.include?(XCFRAMEWORK_DIRECTORY)
+          end
+        end
+        false
       end
     end
   end

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -48,20 +48,8 @@ module SecureKeys
       # Get the XCFramework relative path
       # @return [Pathname] The XCFramework relative path
       def xcframework_relative_path
-        secure_keys_xcframework_path = SecureKeys::Globals.secure_keys_xcframework_path
-        xcodeproj_path = SecureKeys::Globals.xcodeproj_path
-
-        Core::Console::Logger.crash!(message: 'The secure keys XCFramework path or the Xcodeproj path is empty') if secure_keys_xcframework_path.to_s.empty? || xcodeproj_path.to_s.empty?
-
-        secure_keys_xcframework_path_name = Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
-
-        Core::Console::Logger.important(message: "Secure keys XCFramework path: #{secure_keys_xcframework_path_name}")
-
-        xcodeproj_path_name = Pathname.new(SecureKeys::Globals.xcodeproj_path).dirname
-
-        Core::Console::Logger.important(message: "Xcodeproj path: #{xcodeproj_path_name}")
-
-        secure_keys_xcframework_path_name.relative_path_from(xcodeproj_path_name)
+        Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
+                .relative_path_from(Pathname.new(SecureKeys::Globals.xcodeproj_path).dirname)
       end
 
       # Check if the Xcode project has the secure keys XCFramework

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -53,7 +53,11 @@ module SecureKeys
         secure_keys_xcframework_path = SecureKeys::Globals.secure_keys_xcframework_path
         xcodeproj_path = SecureKeys::Globals.xcodeproj_path
 
-        Core::Console::Logger.crash!(message: 'The secure keys XCFramework path or the Xcodeproj path is empty') if secure_keys_xcframework_path.to_s.empty? || xcodeproj_path.to_s.empty?
+        Core::Console::Logger.important(message: "Secure keys XCFramework path: #{secure_keys_xcframework_path}")
+        Core::Console::Logger.important(message: "Xcodeproj path: #{xcodeproj_path}")
+
+        Core::Console::Logger.crash!(message: 'The secure keys XCFramework path is empty') if secure_keys_xcframework_path.to_s.empty?
+        Core::Console::Logger.crash!(message: 'The secure keys Xcodeproj path is empty') if xcodeproj_path.to_s.empty?
 
         secure_keys_xcframework_path_name = Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
 

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -48,8 +48,20 @@ module SecureKeys
       # Get the XCFramework relative path
       # @return [Pathname] The XCFramework relative path
       def xcframework_relative_path
-        Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
-                .relative_path_from(Pathname.new(SecureKeys::Globals.xcodeproj_path).dirname)
+        secure_keys_xcframework_path = SecureKeys::Globals.secure_keys_xcframework_path
+        xcodeproj_path = SecureKeys::Globals.xcodeproj_path
+
+        Core::Console::Logger.crash!(message: 'The secure keys XCFramework path or the Xcodeproj path is empty') if secure_keys_xcframework_path.to_s.empty? || xcodeproj_path.to_s.empty?
+
+        secure_keys_xcframework_path_name = Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
+
+        Core::Console::Logger.important(message: "Secure keys XCFramework path: #{secure_keys_xcframework_path_name}")
+
+        xcodeproj_path_name = Pathname.new(SecureKeys::Globals.xcodeproj_path).dirname
+
+        Core::Console::Logger.important(message: "Xcodeproj path: #{xcodeproj_path_name}")
+
+        secure_keys_xcframework_path_name.relative_path_from(xcodeproj_path_name)
       end
 
       # Check if the Xcode project has the secure keys XCFramework

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -53,11 +53,7 @@ module SecureKeys
         secure_keys_xcframework_path = SecureKeys::Globals.secure_keys_xcframework_path
         xcodeproj_path = SecureKeys::Globals.xcodeproj_path
 
-        Core::Console::Logger.important(message: "Secure keys XCFramework path: #{secure_keys_xcframework_path}")
-        Core::Console::Logger.important(message: "Xcodeproj path: #{xcodeproj_path}")
-
-        Core::Console::Logger.crash!(message: 'The secure keys XCFramework path is empty') if secure_keys_xcframework_path.to_s.empty?
-        Core::Console::Logger.crash!(message: 'The secure keys Xcodeproj path is empty') if xcodeproj_path.to_s.empty?
+        Core::Console::Logger.crash!(message: 'The secure keys XCFramework path or the Xcodeproj path is empty') if secure_keys_xcframework_path.to_s.empty? || xcodeproj_path.to_s.empty?
 
         secure_keys_xcframework_path_name = Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
 

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -48,8 +48,6 @@ module SecureKeys
       # Get the XCFramework relative path
       # @return [Pathname] The XCFramework relative path
       def xcframework_relative_path
-        Core::Console::Logger.important(message: Dir.pwd)
-
         secure_keys_xcframework_path = SecureKeys::Globals.secure_keys_xcframework_path
         xcodeproj_path = SecureKeys::Globals.xcodeproj_path
 

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -49,7 +49,7 @@ module SecureKeys
       # @return [Pathname] The XCFramework relative path
       def xcframework_relative_path
         Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
-                .relative_path_from(Pathname(SecureKeys::Globals.xcodeproj_path).dirname)
+                .relative_path_from(Pathname.new(SecureKeys::Globals.xcodeproj_path).dirname)
       end
 
       # Check if the Xcode project has the secure keys XCFramework

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -1,5 +1,7 @@
 require 'xcodeproj'
 require_relative '../../globals/globals'
+require_relative '../../utils/swift/swift'
+require_relative '../../console/logger'
 
 module SecureKeys
   module Swift
@@ -20,6 +22,7 @@ module SecureKeys
       # @param xcodeproj [Xcodeproj::Project] The Xcodeproj to add the XCFramework
       # @param xcodeproj_target [Xcodeproj] The Xcodeproj target to add the XCFramework
       def add_xcframework_to_build_phases(xcodeproj:, xcodeproj_target:)
+        Core::Console::Logger.crash!(message: "The xcodeproj #{xcodeproj} already have the #{XCFRAMEWORK_DIRECTORY}") if xcodeproj_has_secure_keys_xcframework?(xcodeproj:)
         xcframework_reference = xcodeproj.frameworks_group.new_file(xcframework_relative_path)
         xcodeproj_target.frameworks_build_phase.add_file_reference(xcframework_reference)
       end
@@ -39,9 +42,7 @@ module SecureKeys
       # Get the Xcodeproj
       # @return [Xcodeproj] The Xcodeproj
       def xcodeproj
-        xcodeproj = ::Xcodeproj::Project.open(SecureKeys::Globals.xcodeproj_path)
-        Core::Console::Logger.crash!(message: "The xcodeproj #{xcodeproj} already have the #{XCFRAMEWORK_DIRECTORY}") if xcodeproj_has_secure_keys_xcframework?(xcodeproj:)
-        xcodeproj
+        ::Xcodeproj::Project.open(SecureKeys::Globals.xcodeproj_path)
       end
 
       # Get the XCFramework relative path

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -48,6 +48,8 @@ module SecureKeys
       # Get the XCFramework relative path
       # @return [Pathname] The XCFramework relative path
       def xcframework_relative_path
+        Core::Console::Logger.important(message: Dir.pwd)
+
         secure_keys_xcframework_path = SecureKeys::Globals.secure_keys_xcframework_path
         xcodeproj_path = SecureKeys::Globals.xcodeproj_path
 

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -1,0 +1,68 @@
+require 'xcodeproj'
+require_relative '../../globals/globals'
+
+module SecureKeys
+  module Swift
+    module Xcodeproj
+      module_function
+
+      # Add the SecureKeys XCFramework to the Xcodeproj target build settings
+      # @param target_name [String] The target name to add the XCFramework
+      # @param configurations [Array<String>] The configurations to add the XCFramework
+      def add_framework_search_path(xcodeproj_target:, configurations: %w[Debug Release])
+        configurations.each do |config|
+          paths = ['$(inherited)', "$(SRCROOT)/#{xcframework_relative_path}"]
+          xcodeproj_target.build_settings(config)['FRAMEWORK_SEARCH_PATHS'] = paths
+        end
+      end
+
+      # Add the SecureKeys XCFramework to the Xcodeproj target build phases
+      # @param xcodeproj [Xcodeproj::Project] The Xcodeproj to add the XCFramework
+      # @param xcodeproj_target [Xcodeproj] The Xcodeproj target to add the XCFramework
+      def add_xcframework_to_build_phases(xcodeproj:, xcodeproj_target:)
+        xcframework_reference = xcodeproj.frameworks_group.new_file(xcframework_relative_path)
+        xcodeproj_target.frameworks_build_phase.add_file_reference(xcframework_reference)
+      end
+
+      # Get the Xcodeproj target by target name
+      # @param xcodeproj [Xcodeproj::Project] The Xcodeproj to get the target
+      # @param target_name [String] The target name to get
+      # @return [Xcodeproj] The Xcodeproj target
+      # @raise [StandardError] If the target was not found
+      def xcodeproj_target_by_target_name(xcodeproj:, target_name:)
+        xcodeproj_target = xcodeproj.targets.find { |target| target.name.eql?(target_name) }
+        Core::Console::Logger.crash!(message: "The target #{target_name} was not found") if xcodeproj_target.nil?
+
+        xcodeproj_target
+      end
+
+      # Get the Xcodeproj
+      # @return [Xcodeproj] The Xcodeproj
+      def xcodeproj
+        xcodeproj = ::Xcodeproj::Project.open(SecureKeys::Globals.xcodeproj_path)
+        Core::Console::Logger.crash!(message: "The xcodeproj #{xcodeproj} already have the #{XCFRAMEWORK_DIRECTORY}") if xcodeproj_has_secure_keys_xcframework?(xcodeproj:)
+        xcodeproj
+      end
+
+      # Get the XCFramework relative path
+      # @return [Pathname] The XCFramework relative path
+      def xcframework_relative_path
+        Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
+                .relative_path_from(Pathname(SecureKeys::Globals.xcodeproj_path).dirname)
+      end
+
+      # Check if the Xcode project has the secure keys XCFramework
+      # @param xcodeproj [Xcodeproj::Project] The Xcode project
+      # @return [Bool] true if the Xcode project has the secure keys XCFramework
+      def xcodeproj_has_secure_keys_xcframework?(xcodeproj:)
+        xcodeproj.targets.any? do |target|
+          target.frameworks_build_phase.files.any? do |file|
+            return false if file.file_ref.nil?
+
+            file.file_ref.path.include?(SecureKeys::Globals.secure_keys_xcframework_path)
+          end
+        end
+      end
+    end
+  end
+end

--- a/secure-keys.gemspec
+++ b/secure-keys.gemspec
@@ -42,6 +42,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'optparse', '~> 0.6.0'
   spec.add_runtime_dependency 'osx_keychain', '~> 1.0.2'
   spec.add_runtime_dependency 'tty-screen', '~> 0.8.2'
+  spec.add_runtime_dependency 'xcodeproj', '~> 1.27.0'
   spec.add_development_dependency 'rspec', '~> 3.13.0'
   spec.add_development_dependency 'rubocop', '~> 1.71.2'
   spec.add_development_dependency 'ruby-debug-ide', '~> 0.7.5'

--- a/spec/core/console/arguments/parser_spec.rb
+++ b/spec/core/console/arguments/parser_spec.rb
@@ -21,10 +21,13 @@ describe(SecureKeys::Core::Console::Argument::Parser) do
       'Usage: secure-keys [--options]',
       '',
       '-h, --help                       Use the provided commands to select the params',
+      '--add-xcframework-to-target TARGET',
+      'Add the xcframework to the target',
       '-d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")',
       '-i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")',
       '--verbose                    Enable verbose mode (default: false)',
-      '-v, --version                    Show the secure-keys version'
+      '-v, --version                    Show the secure-keys version',
+      '-x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)'
     ]
 
     # when

--- a/spec/core/utils/xcodeproj_spec.rb
+++ b/spec/core/utils/xcodeproj_spec.rb
@@ -75,19 +75,4 @@ describe(SecureKeys::Swift::Xcodeproj) do
                                                                    target_name: expected_target_name)
     end.to(raise_error(StandardError, expected_error_message))
   end
-
-  it('should get the XCFramework relative path') do
-    # given
-    expected_xcframework_relative_path = '../../../../.secure-keys/SecureKeys.xcframework'
-    expected_xcodeproj_path = 'spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj'
-
-    # when
-    # define the env variable
-    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
-    xcframework_relative_path = SecureKeys::Swift::Xcodeproj.xcframework_relative_path
-
-    # then
-    expect(xcframework_relative_path).not_to(be_nil)
-    expect(xcframework_relative_path.to_s).to(eq(expected_xcframework_relative_path))
-  end
 end

--- a/spec/core/utils/xcodeproj_spec.rb
+++ b/spec/core/utils/xcodeproj_spec.rb
@@ -1,0 +1,83 @@
+require 'core/globals/globals'
+require 'core/console/arguments/handler'
+require 'core/utils/swift/xcodeproj'
+
+describe(SecureKeys::Swift::Xcodeproj) do
+  it('should find the xcodeproj from env variables') do
+    # given
+    expected_target_name = 'SecureKeys'
+    expected_xcodeproj_path = 'spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj'
+
+    # when
+    # define the env variable
+    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
+    xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
+
+    # then
+    expect(xcodeproj).not_to(be_nil)
+    expect(xcodeproj.targets.map(&:name)).to(include(expected_target_name))
+  end
+
+  it('should find the xcodeproj from argument handler') do
+    # given
+    expected_target_name = 'SecureKeys'
+    expected_xcodeproj_path = 'spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj'
+
+    # when
+    # define the argument handler
+    SecureKeys::Core::Console::Argument::Handler.set(key: :xcodeproj, value: expected_xcodeproj_path)
+    xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
+
+    # then
+    expect(xcodeproj).not_to(be_nil)
+    expect(xcodeproj.targets.map(&:name)).to(include(expected_target_name))
+  end
+
+  it('should find the xcodeproj target by target name') do
+    # given
+    expected_target_name = 'SecureKeys'
+    expected_xcodeproj_path = 'spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj'
+
+    # when
+    # define the env variable
+    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
+    xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
+    xcodeproj_target = SecureKeys::Swift::Xcodeproj.xcodeproj_target_by_target_name(xcodeproj:,
+                                                                                    target_name: expected_target_name)
+
+    # then
+    expect(xcodeproj_target).not_to(be_nil)
+    expect(xcodeproj_target.name).to(eq(expected_target_name))
+  end
+
+  it("shouldn't find the xcodeproj target by target name") do
+    # given
+    expected_target_name = 'Invalid-SecureKeys'
+    expected_error_message = "The target #{expected_target_name} was not found"
+    expected_xcodeproj_path = 'spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj'
+
+    # when
+    # define the env variable
+    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
+    xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
+
+    # then
+    expect do
+      SecureKeys::Swift::Xcodeproj.xcodeproj_target_by_target_name(xcodeproj:,
+                                                                   target_name: expected_target_name)
+    end.to(raise_error(StandardError, expected_error_message))
+  end
+
+  it('should get the XCFramework relative path') do
+    # given
+    expected_xcframework_relative_path = '../../../../.secure-keys/SecureKeys.xcframework'
+
+    # when
+    # define the env variable
+    xcframework_relative_path = SecureKeys::Swift::Xcodeproj.xcframework_relative_path
+
+    # then
+    expect(xcframework_relative_path).not_to(be_nil)
+    expect(xcframework_relative_path.to_s).to(eq(expected_xcframework_relative_path))
+  end
+end

--- a/spec/core/utils/xcodeproj_spec.rb
+++ b/spec/core/utils/xcodeproj_spec.rb
@@ -3,6 +3,14 @@ require 'core/console/arguments/handler'
 require 'core/utils/swift/xcodeproj'
 
 describe(SecureKeys::Swift::Xcodeproj) do
+  before(:each) do
+    # reset the argument handler
+    SecureKeys::Core::Console::Argument::Handler.reset
+
+    # reset the env variable
+    ENV['SECURE_KEYS_XCODEPROJ'] = nil
+  end
+
   it('should find the xcodeproj from env variables') do
     # given
     expected_target_name = 'SecureKeys'
@@ -71,9 +79,11 @@ describe(SecureKeys::Swift::Xcodeproj) do
   it('should get the XCFramework relative path') do
     # given
     expected_xcframework_relative_path = '../../../../.secure-keys/SecureKeys.xcframework'
+    expected_xcodeproj_path = 'spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj'
 
     # when
     # define the env variable
+    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
     xcframework_relative_path = SecureKeys::Swift::Xcodeproj.xcframework_relative_path
 
     # then

--- a/spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj/project.pbxproj
+++ b/spec/fixtures/ios/SecureKeys/SecureKeys.xcodeproj/project.pbxproj
@@ -1,0 +1,394 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 77;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		E03C1A192D6C07A200B7EF48 /* SecureKeys.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = E0F68F382D6BFFB0007B55BC /* SecureKeys.xcframework */; };
+		E03C1A1A2D6C07A200B7EF48 /* SecureKeys.xcframework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = E0F68F382D6BFFB0007B55BC /* SecureKeys.xcframework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		E0E91F282D6BFE6D003DCD3B /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = E0E91F272D6BFE6D003DCD3B /* FirebaseAnalytics */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		E03C1A1B2D6C07A200B7EF48 /* Embed Frameworks */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 10;
+			files = (
+				E03C1A1A2D6C07A200B7EF48 /* SecureKeys.xcframework in Embed Frameworks */,
+			);
+			name = "Embed Frameworks";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
+/* Begin PBXFileReference section */
+		E0E91F0E2D6BFD00003DCD3B /* SecureKeys.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = SecureKeys.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		E0F68F382D6BFFB0007B55BC /* SecureKeys.xcframework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcframework; name = SecureKeys.xcframework; path = "../../.secure-keys/SecureKeys.xcframework"; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
+		E0E91F202D6BFD02003DCD3B /* Exceptions for "SecureKeys" folder in "SecureKeys" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				Info.plist,
+			);
+			target = E0E91F0D2D6BFD00003DCD3B /* SecureKeys */;
+		};
+/* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
+
+/* Begin PBXFileSystemSynchronizedRootGroup section */
+		E0E91F102D6BFD00003DCD3B /* SecureKeys */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				E0E91F202D6BFD02003DCD3B /* Exceptions for "SecureKeys" folder in "SecureKeys" target */,
+			);
+			path = SecureKeys;
+			sourceTree = "<group>";
+		};
+/* End PBXFileSystemSynchronizedRootGroup section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		E0E91F0B2D6BFD00003DCD3B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				E03C1A192D6C07A200B7EF48 /* SecureKeys.xcframework in Frameworks */,
+				E0E91F282D6BFE6D003DCD3B /* FirebaseAnalytics in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		E0E91F052D6BFD00003DCD3B = {
+			isa = PBXGroup;
+			children = (
+				E0E91F102D6BFD00003DCD3B /* SecureKeys */,
+				E0F68F372D6BFFAF007B55BC /* Frameworks */,
+				E0E91F0F2D6BFD00003DCD3B /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		E0E91F0F2D6BFD00003DCD3B /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				E0E91F0E2D6BFD00003DCD3B /* SecureKeys.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		E0F68F372D6BFFAF007B55BC /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				E0F68F382D6BFFB0007B55BC /* SecureKeys.xcframework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		E0E91F0D2D6BFD00003DCD3B /* SecureKeys */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E0E91F212D6BFD02003DCD3B /* Build configuration list for PBXNativeTarget "SecureKeys" */;
+			buildPhases = (
+				E0E91F0A2D6BFD00003DCD3B /* Sources */,
+				E0E91F0B2D6BFD00003DCD3B /* Frameworks */,
+				E0E91F0C2D6BFD00003DCD3B /* Resources */,
+				E03C1A1B2D6C07A200B7EF48 /* Embed Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			fileSystemSynchronizedGroups = (
+				E0E91F102D6BFD00003DCD3B /* SecureKeys */,
+			);
+			name = SecureKeys;
+			packageProductDependencies = (
+				E0E91F272D6BFE6D003DCD3B /* FirebaseAnalytics */,
+			);
+			productName = SecureKeys;
+			productReference = E0E91F0E2D6BFD00003DCD3B /* SecureKeys.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		E0E91F062D6BFD00003DCD3B /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1600;
+				LastUpgradeCheck = 1600;
+				TargetAttributes = {
+					E0E91F0D2D6BFD00003DCD3B = {
+						CreatedOnToolsVersion = 16.0;
+					};
+				};
+			};
+			buildConfigurationList = E0E91F092D6BFD00003DCD3B /* Build configuration list for PBXProject "SecureKeys" */;
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = E0E91F052D6BFD00003DCD3B;
+			minimizedProjectReferenceProxies = 1;
+			packageReferences = (
+				E0E91F262D6BFE6C003DCD3B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
+			preferredProjectObjectVersion = 77;
+			productRefGroup = E0E91F0F2D6BFD00003DCD3B /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				E0E91F0D2D6BFD00003DCD3B /* SecureKeys */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		E0E91F0C2D6BFD00003DCD3B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		E0E91F0A2D6BFD00003DCD3B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin XCBuildConfiguration section */
+		E0E91F222D6BFD02003DCD3B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SecureKeys/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.secure-keys.SecureKeys";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		E0E91F232D6BFD02003DCD3B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = SecureKeys/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.secure-keys.SecureKeys";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+		E0E91F242D6BFD02003DCD3B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		E0E91F252D6BFD02003DCD3B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		E0E91F092D6BFD00003DCD3B /* Build configuration list for PBXProject "SecureKeys" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E0E91F242D6BFD02003DCD3B /* Debug */,
+				E0E91F252D6BFD02003DCD3B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E0E91F212D6BFD02003DCD3B /* Build configuration list for PBXNativeTarget "SecureKeys" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				E0E91F222D6BFD02003DCD3B /* Debug */,
+				E0E91F232D6BFD02003DCD3B /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		E0E91F262D6BFE6C003DCD3B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 11.8.1;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		E0E91F272D6BFE6D003DCD3B /* FirebaseAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E0E91F262D6BFE6C003DCD3B /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseAnalytics;
+		};
+/* End XCSwiftPackageProductDependency section */
+	};
+	rootObject = E0E91F062D6BFD00003DCD3B /* Project object */;
+}


### PR DESCRIPTION
### Description

This PR added two new CLI arguments (`--add-xcframework-to-target [TARGET]` and `--xcodeproj XCODEPROJ`) to handle the `xcframework` integration to any xcodeproj.

### Medias (if needed)

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/3af83027-6849-46f7-b9da-fe8c94aeb29b" />

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/ef3fdb5b-3566-45e6-8a6e-60e457eab9ca" />

### Testplan

- [x] I tested this change on my local environment.
- [x] I ran the unit tests.

### Checklist

- [x] I added tests for this change.
- [x] I checked the code style and run the linter.
- [x] I added necessary documentation (if applicable).
