### PR TITLE
Refactor SecureKeys xcframework cli interaction

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ secure-keys --xcframework --target "YourTargetName" --replace
 ```
 
 > [!IMPORTANT]
-> If you don't need generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
+> If you don't need to generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
 
 ```bash
 secure-keys --no-generate --xcframework --target "YourTargetName"

--- a/README.md
+++ b/README.md
@@ -137,13 +137,13 @@ secure-keys --help
 
 Usage: secure-keys [--options]
 
-    -h, --help                                  Use the provided commands to select the params
-        --add-xcframework-to-target TARGET      Add the xcframework to the target
-    -d, --delimiter DELIMITER                   The delimiter to use for the key access (default: ",")
-    -i, --identifier IDENTIFIER                 The identifier to use for the key access (default: "secure-keys")
-        --verbose                               Enable verbose mode (default: false)
-    -v, --version                               Show the secure-keys version
-    -x, --xcodeproj XCODEPROJ                   The Xcode project path (default: the first found Xcode project)
+    -h, --help                       Use the provided commands to select the params
+        --xcframework                Add the xcframework to the target
+    -d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")
+        --[no-]generate              Generate the SecureKeys.xcframework
+    -i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")
+        --verbose                    Enable verbose mode (default: false)
+    -v, --version                    Show the secure-keys version
 ```
 
 To avoid defining the `SECURE_KEYS_IDENTIFIER` and `SECURE_KEYS_DELIMITER` env variables, you can use the `--identifier` and `--delimiter` options.
@@ -188,22 +188,68 @@ let apiKey: String = .key(for: .apiKey)
 
 ### Automatically
 
-From the `secure-keys` command, you can use the `--add-xcframework-to-target` option to add the `SecureKeys.xcframework` to the iOS project.
+> [!IMPORTANT]
+> You can see more information about the command using the `--help` option.
 
 ```bash
-secure-keys --add-xcframework-to-target "YourTargetName"
+secure-keys --xcframework --help
+
+# Output
+Usage: secure-keys --xcframework [--options]
+
+    -h, --help                       Use the provided commands to select the params
+        --[no-]add                   Add the SecureKeys XCFramework to the Xcode project (default: true)
+    -t, --target TARGET              The target to add the xcframework
+    -r, --replace                    Replace the existing xcframework in the Xcode project (default: false)
+    -x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)
+```
+
+From the `secure-keys` command, you can use the `--xcframework` option to add the `SecureKeys.xcframework` to the iOS project.
+
+```bash
+secure-keys --xcframework --target "YourTargetName" --add
+```
+
+If you want to add the `SecureKeys.xcframework` to an iOS that already contains the `SecureKeys` source code, you can use the `--replace` option.
+
+```bash
+secure-keys --xcframework --target "YourTargetName" --replace
+```
+
+> [!IMPORTANT]
+> If you don't need generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
+
+```bash
+secure-keys --no-generate --xcframework --target "YourTargetName"
 ```
 
 Also, you can specify your Xcode project path using the `--xcodeproj` option.
 
 ```bash
-secure-keys --add-xcframework-to-target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
+secure-keys --xcframework --target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
 ```
 
 > [!IMPORTANT]
 > By default, the xcodeproj path would be the first found Xcode project.
 
-This command will generate the `SecureKeys.xcframework` and add it to the iOS project.
+If you don't want to use the CLI options, you can configure some env variable to interact with the `secure-keys` command.
+
+```bash
+# e.g (Large version)
+export SECURE_KEYS_XCFRAMEWORK_TARGET="YourTargetName"
+export SECURE_KEYS_XCFRAMEWORK_ADD=true
+export SECURE_KEYS_XCFRAMEWORK_REPLACE=true
+export SECURE_KEYS_XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
+
+# e.g (Short version)
+export XCFRAMEWORK_TARGET="YourTargetName"
+export XCFRAMEWORK_ADD=true
+export XCFRAMEWORK_REPLACE=true
+export XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
+
+# Run the command
+secure-keys --xcframework
+```
 
 ### Manually
 

--- a/bin/secure-keys
+++ b/bin/secure-keys
@@ -5,4 +5,4 @@ require 'dotenv/load'
 require_relative '../lib/keys'
 
 # Generate the keys
-SecureKeys::Generator.new.setup
+SecureKeys.run

--- a/docs/index.md
+++ b/docs/index.md
@@ -133,13 +133,13 @@ secure-keys --help
 
 Usage: secure-keys [--options]
 
-    -h, --help                                  Use the provided commands to select the params
-        --add-xcframework-to-target TARGET      Add the xcframework to the target
-    -d, --delimiter DELIMITER                   The delimiter to use for the key access (default: ",")
-    -i, --identifier IDENTIFIER                 The identifier to use for the key access (default: "secure-keys")
-        --verbose                               Enable verbose mode (default: false)
-    -v, --version                               Show the secure-keys version
-    -x, --xcodeproj XCODEPROJ                   The Xcode project path (default: the first found Xcode project)
+    -h, --help                       Use the provided commands to select the params
+        --xcframework                Add the xcframework to the target
+    -d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")
+        --[no-]generate              Generate the SecureKeys.xcframework
+    -i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")
+        --verbose                    Enable verbose mode (default: false)
+    -v, --version                    Show the secure-keys version
 ```
 
 To avoid defining the `SECURE_KEYS_IDENTIFIER` and `SECURE_KEYS_DELIMITER` env variables, you can use the `--identifier` and `--delimiter` options.
@@ -158,22 +158,68 @@ secure-keys -i "your-keychain-or-env-variable-identifier" -d "|"
 
 #### Automatically
 
-From the `secure-keys` command, you can use the `--add-xcframework-to-target` option to add the `SecureKeys.xcframework` to the iOS project.
+> [!IMPORTANT]
+> You can see more information about the command using the `--help` option.
 
 ```bash
-secure-keys --add-xcframework-to-target "YourTargetName"
+secure-keys --xcframework --help
+
+# Output
+Usage: secure-keys --xcframework [--options]
+
+    -h, --help                       Use the provided commands to select the params
+        --[no-]add                   Add the SecureKeys XCFramework to the Xcode project (default: true)
+    -t, --target TARGET              The target to add the xcframework
+    -r, --replace                    Replace the existing xcframework in the Xcode project (default: false)
+    -x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)
+```
+
+From the `secure-keys` command, you can use the `--xcframework` option to add the `SecureKeys.xcframework` to the iOS project.
+
+```bash
+secure-keys --xcframework --target "YourTargetName" --add
+```
+
+If you want to add the `SecureKeys.xcframework` to an iOS that already contains the `SecureKeys` source code, you can use the `--replace` option.
+
+```bash
+secure-keys --xcframework --target "YourTargetName" --replace
+```
+
+> [!IMPORTANT]
+> If you don't need generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
+
+```bash
+secure-keys --no-generate --xcframework --target "YourTargetName"
 ```
 
 Also, you can specify your Xcode project path using the `--xcodeproj` option.
 
 ```bash
-secure-keys --add-xcframework-to-target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
+secure-keys --xcframework --target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
 ```
 
 > [!IMPORTANT]
 > By default, the xcodeproj path would be the first found Xcode project.
 
-This command will generate the `SecureKeys.xcframework` and add it to the iOS project.
+If you don't want to use the CLI options, you can configure some env variable to interact with the `secure-keys` command.
+
+```bash
+# e.g (Large version)
+export SECURE_KEYS_XCFRAMEWORK_TARGET="YourTargetName"
+export SECURE_KEYS_XCFRAMEWORK_ADD=true
+export SECURE_KEYS_XCFRAMEWORK_REPLACE=true
+export SECURE_KEYS_XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
+
+# e.g (Short version)
+export XCFRAMEWORK_TARGET="YourTargetName"
+export XCFRAMEWORK_ADD=true
+export XCFRAMEWORK_REPLACE=true
+export XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
+
+# Run the command
+secure-keys --xcframework
+```
 
 #### Manually
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -187,7 +187,7 @@ secure-keys --xcframework --target "YourTargetName" --replace
 ```
 
 > [!IMPORTANT]
-> If you don't need generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
+> If you don't need to generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
 
 ```bash
 secure-keys --no-generate --xcframework --target "YourTargetName"

--- a/fixtures/SwiftUIApp+Backend/README.md
+++ b/fixtures/SwiftUIApp+Backend/README.md
@@ -25,7 +25,8 @@ Later, you can generate the `SecureKeys` xcframework by running the following co
 ```bash
 # Running in the root project directory
 secure-keys \
-  --add-xcframework-to-target SwiftUIApp \
+  --xcframework \
+  --target "SwiftUIApp" \
   --xcodeproj "fixtures/SwiftUIApp+Backend/client/SwiftUIApp.xcodeproj"
 ```
 

--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -10,6 +10,7 @@ module SecureKeys
           # Configure the default arguments
           @arguments = {
             delimiter: nil,
+            generate: true,
             identifier: nil,
             verbose: false,
           }

--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -18,12 +18,14 @@ module SecureKeys
           # Fetch the argument value by key
           # from CLI arguments or environment variables
           #
-          # @param key [Symbol] the argument key
+          # @param key [Array|Symbol] the argument key
           # @param default [String] the default value
           #
           # @return [String] the argument value
           def self.fetch(key:, default: nil)
-            @arguments.dig(*Array(key).map(&:to_sym)) || ENV.fetch("secure_keys_#{key}".upcase, nil) || default
+            keys = Array(key).map(&:to_sym)
+            joined_keys = keys.join('_').upcase
+            @arguments.dig(*keys) || ENV["SECURE_KEYS_#{joined_keys}"] || ENV[joined_keys] || default
           end
 
           # Set the value of the key
@@ -37,7 +39,8 @@ module SecureKeys
           # @param key [Symbol] the argument key
           # @param value [String] the argument value
           def self.deep_merge(key:, value:)
-            @arguments[key.to_sym].deep_merge(value)
+            @arguments[key.to_sym] ||= {} # Initialize the key if it doesn't exist
+            @arguments[key.to_sym].merge!(value)
           end
         end
       end

--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -22,19 +22,21 @@ module SecureKeys
           #
           # @return [String] the argument value
           def self.fetch(key:, default: nil)
-            # We need to check if the key is an array to handle the fetch
-            # as deep search
             @arguments.dig(*Array(key).map(&:to_sym)) || ENV.fetch("secure_keys_#{key}".upcase, nil) || default
+          end
+
+          # Set the value of the key
+          # @param key [Symbol] the key to be updated
+          # @param value [String] the value to be updated
+          def self.set(key:, value:)
+            @arguments[key.to_sym] = value
           end
 
           # Append the argument value by key
           # @param key [Symbol] the argument key
           # @param value [String] the argument value
-          def self.append(key:, value:)
-            # We need to check if the key is already set to avoid overriding
-            return unless @arguments[key.to_sym].nil?
-
-            @arguments[key.to_sym] = value
+          def self.deep_merge(key:, value:)
+            @arguments[key.to_sym].deep_merge(value)
           end
         end
       end

--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -11,9 +11,7 @@ module SecureKeys
           @arguments = {
             delimiter: nil,
             identifier: nil,
-            target: nil,
             verbose: false,
-            xcodeproj: nil,
           }
 
           # Fetch the argument value by key
@@ -24,7 +22,19 @@ module SecureKeys
           #
           # @return [String] the argument value
           def self.fetch(key:, default: nil)
-            @arguments[key.to_sym] || ENV.fetch("secure_keys_#{key}".upcase, nil) || default
+            # We need to check if the key is an array to handle the fetch
+            # as deep search
+            @arguments.dig(*Array(key).map(&:to_sym)) || ENV.fetch("secure_keys_#{key}".upcase, nil) || default
+          end
+
+          # Append the argument value by key
+          # @param key [Symbol] the argument key
+          # @param value [String] the argument value
+          def self.append(key:, value:)
+            # We need to check if the key is already set to avoid overriding
+            return unless @arguments[key.to_sym].nil?
+
+            @arguments[key.to_sym] = value
           end
         end
       end

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -35,6 +35,7 @@ module SecureKeys
             end
 
             on('-d', '--delimiter DELIMITER', String, "The delimiter to use for the key access (default: \"#{Globals.default_key_delimiter}\")")
+            on('--[no-]generate', TrueClass, 'Generate the SecureKeys.xcframework')
             on('-i', '--identifier IDENTIFIER', String, "The identifier to use for the key access (default: \"#{Globals.default_key_access_identifier}\")")
             on('--verbose', TrueClass, 'Enable verbose mode (default: false)')
 

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -18,7 +18,7 @@ module SecureKeys
             # Configure the arguement parser
             configure!
             order!(into: Handler.arguments)
-            append_sub_arguments
+            configure_sub_arguments
           end
 
           private
@@ -30,7 +30,7 @@ module SecureKeys
               exit(0)
             end
 
-            on('--xcframework', Object, 'Add the xcframework to the target') do
+            on('--xcframework', 'Add the xcframework to the target') do
               XCFramework::Parser.new
             end
 
@@ -44,9 +44,9 @@ module SecureKeys
             end
           end
 
-          # Append the sub arguments
-          def append_sub_arguments
-            Handler.append(key: :xcframework, arguments: XCFramework::Handler.arguments)
+          # Configure the sub arguments
+          def configure_sub_arguments
+            Handler.set(key: :xcframework, value: XCFramework::Handler.arguments)
           end
         end
       end

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -3,6 +3,7 @@
 require 'optparse'
 require_relative '../../globals/globals'
 require_relative './handler'
+require_relative './xcframework/parser'
 
 module SecureKeys
   module Core
@@ -16,7 +17,8 @@ module SecureKeys
 
             # Configure the arguement parser
             configure!
-            parse!(into: Handler.arguments)
+            order!(into: Handler.arguments)
+            append_sub_arguments
           end
 
           private
@@ -28,18 +30,23 @@ module SecureKeys
               exit(0)
             end
 
-            on('--add-xcframework-to-target TARGET', String, 'Add the xcframework to the target') do |target|
-              Handler.arguments[:target] = target
+            on('--xcframework', Object, 'Add the xcframework to the target') do
+              XCFramework::Parser.new
             end
+
             on('-d', '--delimiter DELIMITER', String, "The delimiter to use for the key access (default: \"#{Globals.default_key_delimiter}\")")
             on('-i', '--identifier IDENTIFIER', String, "The identifier to use for the key access (default: \"#{Globals.default_key_access_identifier}\")")
             on('--verbose', TrueClass, 'Enable verbose mode (default: false)')
 
-            on('-v', '--version', 'Show the secure-keys version') do
+            on('-v', '--version', FalseClass, 'Show the secure-keys version') do
               puts "secure-keys version: v#{SecureKeys::VERSION}"
               exit(0)
             end
-            on('-x', '--xcodeproj XCODEPROJ', String, 'The Xcode project path (default: the first found Xcode project)')
+          end
+
+          # Append the sub arguments
+          def append_sub_arguments
+            Handler.append(key: :xcframework, arguments: XCFramework::Handler.arguments)
           end
         end
       end

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -39,7 +39,7 @@ module SecureKeys
             on('-i', '--identifier IDENTIFIER', String, "The identifier to use for the key access (default: \"#{Globals.default_key_access_identifier}\")")
             on('--verbose', TrueClass, 'Enable verbose mode (default: false)')
 
-            on('-v', '--version', FalseClass, 'Show the secure-keys version') do
+            on('-v', '--version', 'Show the secure-keys version') do
               puts "secure-keys version: v#{SecureKeys::VERSION}"
               exit(0)
             end

--- a/lib/core/console/arguments/xcframework/handler.rb
+++ b/lib/core/console/arguments/xcframework/handler.rb
@@ -1,0 +1,22 @@
+module SecureKeys
+  module Core
+    module Console
+      module Argument
+        module XCFramework
+          class Handler
+            class << self
+              attr_reader :arguments
+            end
+
+            # Configure the default arguments
+            @arguments = {
+              replace: false,
+              target: nil,
+              xcodeproj: nil,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/core/console/arguments/xcframework/handler.rb
+++ b/lib/core/console/arguments/xcframework/handler.rb
@@ -10,6 +10,7 @@ module SecureKeys
 
             # Configure the default arguments
             @arguments = {
+              add: true,
               replace: false,
               target: nil,
               xcodeproj: nil,

--- a/lib/core/console/arguments/xcframework/parser.rb
+++ b/lib/core/console/arguments/xcframework/parser.rb
@@ -1,0 +1,41 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require_relative '../../../globals/globals'
+require_relative './handler'
+
+module SecureKeys
+  module Core
+    module Console
+      module Argument
+        module XCFramework
+          class Parser < OptionParser
+            # Initialize the argument parser with the default options
+            def initialize
+              super('Usage: secure-keys --xcframework [--options]')
+              separator('')
+
+              # Configure the arguement parser
+              configure!
+              order!(into: Handler.arguments)
+            end
+
+            private
+
+            # Configure the argument parser
+            def configure!
+              on('-h', '--help', 'Use the provided commands to select the params') do
+                puts self
+                exit(0)
+              end
+
+              on('-t', '--target TARGET', String, 'The target to add the xcframework')
+              on('-r', '--replace', FalseClass, 'Replace the existing xcframework')
+              on('-x', '--xcodeproj XCODEPROJ', String, 'The Xcode project path (default: the first found Xcode project)')
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/core/console/arguments/xcframework/parser.rb
+++ b/lib/core/console/arguments/xcframework/parser.rb
@@ -29,8 +29,9 @@ module SecureKeys
                 exit(0)
               end
 
+              on('--[no-]add', TrueClass, 'Add the SecureKeys XCFramework to the Xcode project (default: true)')
               on('-t', '--target TARGET', String, 'The target to add the xcframework')
-              on('-r', '--replace', FalseClass, 'Replace the existing xcframework')
+              on('-r', '--replace', TrueClass, 'Replace the existing xcframework in the Xcode project (default: false)')
               on('-x', '--xcodeproj XCODEPROJ', String, 'The Xcode project path (default: the first found Xcode project)')
             end
           end

--- a/lib/core/environment/ci.rb
+++ b/lib/core/environment/ci.rb
@@ -8,18 +8,9 @@ module SecureKeys
         # @param key [String] the key of the environment variable to fetch
         # @return [String] the value of the environment variable
         def fetch(key:)
-          ENV[formatted_key(key:)]
+          ENV[key]
         rescue StandardError
           puts "❌ Error fetching the key: #{key} from ENV variables"
-        end
-
-        private
-
-        # Formats the key to match the format of the environment variables.
-        # @param key [String] the key to format
-        # @return [String] the formatted key
-        def formatted_key(key:)
-          key.gsub('-', '_').uppercase
         end
       end
     end

--- a/lib/core/generator.rb
+++ b/lib/core/generator.rb
@@ -1,6 +1,5 @@
 #!/usr/bin/env ruby
 
-require_relative './utils/extensions/kernel'
 require_relative './globals/globals'
 require_relative './environment/ci'
 require_relative './environment/keychain'

--- a/lib/core/generator.rb
+++ b/lib/core/generator.rb
@@ -1,0 +1,72 @@
+#!/usr/bin/env ruby
+
+require_relative './utils/extensions/kernel'
+require_relative './globals/globals'
+require_relative './environment/ci'
+require_relative './environment/keychain'
+require_relative './utils/swift/writer'
+require_relative './utils/swift/package'
+require_relative './utils/swift/swift'
+require_relative './utils/swift/xcframework'
+require_relative './utils/openssl/cipher'
+
+module SecureKeys
+  module Core
+    class Generator
+      private
+
+      attr_accessor :cipher, :secrets_source, :secret_keys, :mapped_keys
+
+      public
+
+      def initialize
+        # Configure cipher
+        self.cipher = OpenSSL::Cipher.new
+        self.secrets_source = Globals.secret_keys_source
+
+        # Define the keys that we want to map
+        self.secret_keys = secrets_source.fetch(key: Globals.key_access_identifier)
+                                         .to_s
+                                         .split(Globals.key_delimiter)
+                                         .map(&:strip)
+
+        # Add the keys that we want to map
+        self.mapped_keys = secret_keys.map do |key|
+          encrypted_data = cipher.encrypt(value: secrets_source.fetch(key:))
+          { name: key.camelize, **encrypted_data }
+        end
+      end
+
+      def generate
+        pre_actions
+
+        package = Swift::Package.new
+        package.generate
+
+        writer = Swift::Writer.new(mapped_keys:,
+                                   secure_key_bytes: cipher.secure_key_bytes)
+        writer.write
+
+        xcframework = Swift::XCFramework.new
+        xcframework.generate
+
+        post_actions
+      end
+
+      private
+
+      def pre_actions
+        # Remove the keys directory
+        system("rm -rf #{Swift::KEYS_DIRECTORY}")
+      end
+
+      def post_actions
+        # Remove the keys directory
+        system("rm -rf #{Swift::SWIFT_PACKAGE_DIRECTORY}")
+
+        # Remove the build directory
+        system("rm -rf #{Swift::KEYS_DIRECTORY}/#{Swift::BUILD_DIRECTORY}")
+      end
+    end
+  end
+end

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -28,8 +28,8 @@ module SecureKeys
     # Check if the current instance is verbose
     # @return [Bool] true if the current instance is verbose
     def verbose?
-      Core::Console::Argument::Handler.fetch(key: :verbose,
-                                             default: ENV.fetch('VERBOSE', 'false'))
+      Core::Console::Argument::Handler.fetch(key: :verbose)
+                                      .to_s
                                       .to_boolean
     end
 
@@ -37,18 +37,24 @@ module SecureKeys
     # @return [Bool] true if the SecureKeys XCFramework should be generated
     def generate_xcframework?
       Core::Console::Argument::Handler.fetch(key: :generate)
+                                      .to_s
+                                      .to_boolean
     end
 
     # Check if the SecureKeys XCFramework should be replaced
     # @return [Bool] true if the SecureKeys XCFramework should be replaced
     def replace_xcframework?
       Core::Console::Argument::Handler.fetch(key: %i[xcframework replace])
+                                      .to_s
+                                      .to_boolean
     end
 
     # Check if the SecureKeys XCFramework should be added
     # @return [Bool] true if the SecureKeys XCFramework should be added
     def add_xcframework?
       Core::Console::Argument::Handler.fetch(key: %i[xcframework add])
+                                      .to_s
+                                      .to_boolean
     end
 
     # Returns the Xcode project path

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -36,7 +36,7 @@ module SecureKeys
     # Returns the Xcode project path
     # @return [String] Xcode project path
     def xcodeproj_path
-      Core::Console::Argument::Handler.fetch(key: :xcodeproj,
+      Core::Console::Argument::Handler.fetch(key: %i[xcframework xcodeproj],
                                              default: Dir.glob('**/*.xcodeproj').first)
     end
 

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -39,6 +39,18 @@ module SecureKeys
       Core::Console::Argument::Handler.fetch(key: :generate)
     end
 
+    # Check if the SecureKeys XCFramework should be replaced
+    # @return [Bool] true if the SecureKeys XCFramework should be replaced
+    def replace_xcframework?
+      Core::Console::Argument::Handler.fetch(key: %i[xcframework replace])
+    end
+
+    # Check if the SecureKeys XCFramework should be added
+    # @return [Bool] true if the SecureKeys XCFramework should be added
+    def add_xcframework?
+      Core::Console::Argument::Handler.fetch(key: %i[xcframework add])
+    end
+
     # Returns the Xcode project path
     # @return [String] Xcode project path
     def xcodeproj_path

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -33,6 +33,12 @@ module SecureKeys
                                       .to_boolean
     end
 
+    # Check if the SecureKeys XCFramework should be generated
+    # @return [Bool] true if the SecureKeys XCFramework should be generated
+    def generate_xcframework?
+      Core::Console::Argument::Handler.fetch(key: :generate)
+    end
+
     # Returns the Xcode project path
     # @return [String] Xcode project path
     def xcodeproj_path
@@ -44,6 +50,14 @@ module SecureKeys
     # @return [String] secure keys XCFramework path
     def secure_keys_xcframework_path
       Dir.glob("**/#{Swift::KEYS_DIRECTORY}/#{Swift::XCFRAMEWORK_DIRECTORY}").first
+    end
+
+    # Determine the secret keys source based on the environment
+    # @return [Object] secret keys source
+    def secret_keys_source
+      return SecureKeys::Core::Environment::CI.new if ci?
+
+      SecureKeys::Core::Environment::Keychain.new
     end
 
     # Returns the supported iOS platforms

--- a/lib/core/utils/extensions/kernel.rb
+++ b/lib/core/utils/extensions/kernel.rb
@@ -1,8 +1,13 @@
 require_relative './string/to_bool'
+require_relative './string/camelize'
 
 module Kernel
   include BooleanCasting
+  include Camelize
 
   String.include(BooleanCasting)
   String.singleton_class.include(BooleanCasting)
+
+  String.include(Camelize)
+  String.singleton_class.include(Camelize)
 end

--- a/lib/core/utils/extensions/string/camelize.rb
+++ b/lib/core/utils/extensions/string/camelize.rb
@@ -3,13 +3,9 @@ module Camelize
   # Convert a string to camel case format
   # @return [String] the camel case formatted string
   def camelize
-    words = gsub(/[-_\s]+/, ' ') # Replace underscores, dashes, and spaces with a single space
-            .split(/(?=[A-Z])|\s+/) # Split the string into words while preserving uppercase transitions
-            .map(&:downcase) # Convert everything to lowercase to handle uppercase env variables
+    words = split(/(?<=[a-z])(?=[A-Z])|[-_\s]+/) # Split at lowercase-to-uppercase transitions or explicit separators
+            .map(&:downcase) # Convert everything to lowercase for consistency
 
-    # Lowercase the first word and capitalize the rest
-    words.map.with_index do |word, index|
-      index.zero? ? word : word.capitalize
-    end.join
+    words.map.with_index { |word, index| index.zero? ? word : word.capitalize }.join
   end
 end

--- a/lib/core/utils/extensions/string/camelize.rb
+++ b/lib/core/utils/extensions/string/camelize.rb
@@ -1,0 +1,15 @@
+# Adds some useful methods to the String class
+module Camelize
+  # Convert a string to camel case format
+  # @return [String] the camel case formatted string
+  def camelize
+    words = gsub(/[-_\s]+/, ' ') # Replace underscores, dashes, and spaces with a single space
+            .split(/(?=[A-Z])|\s+/) # Split the string into words while preserving uppercase transitions
+            .map(&:downcase) # Convert everything to lowercase to handle uppercase env variables
+
+    # Lowercase the first word and capitalize the rest
+    words.map.with_index do |word, index|
+      index.zero? ? word : word.capitalize
+    end.join
+  end
+end

--- a/lib/core/utils/extensions/string/to_bool.rb
+++ b/lib/core/utils/extensions/string/to_bool.rb
@@ -3,8 +3,10 @@ module BooleanCasting
   # Casts a string to a boolean
   # @return [Boolean] the boolean value of the string
   def to_bool
-    return true if self == true || self =~ /^(true|t|yes|y|1)$/i
-    return false if self == false || empty? || self =~ /^(false|f|no|n|0)$/i
+    return self if [true, false].include?(self)
+    return false if nil? || empty?
+    return false if self =~ /^(false|f|no|n|0)$/i
+    return true if self =~ /^(true|t|yes|y|1)$/i
 
     # If the string is not a boolean, return false by default
     false

--- a/lib/core/utils/swift/xcframework.rb
+++ b/lib/core/utils/swift/xcframework.rb
@@ -85,7 +85,7 @@ module SecureKeys
       # Add the XCFramework to the Xcode project target if needed
       # @param target_name [String] The target name to add the XCFramework
       def add_xcframework_to_xcodeproj_target_if_needed(target_name: nil)
-        target_name ||= Core::Console::Argument::Handler.fetch(key: :target)
+        target_name ||= Core::Console::Argument::Handler.fetch(key: %i[xcframework target])
         return if target_name.to_s.empty?
 
         Core::Console::Logger.important(message: "Adding the XCFramework to the target '#{target_name}'")

--- a/lib/core/utils/swift/xcframework.rb
+++ b/lib/core/utils/swift/xcframework.rb
@@ -25,6 +25,11 @@ module SecureKeys
         add_xcframework_to_xcodeproj_target_if_needed
       end
 
+      def replace_xcframework_in_xcodeproj
+        remove_xcframework_from_xcodeproj_target_if_needed
+        add_xcframework_to_xcodeproj_target_if_needed
+      end
+
       private
 
       # Generate the Swift package modules
@@ -96,6 +101,21 @@ module SecureKeys
 
         xcodeproj.save
         Core::Console::Logger.success(message: "The XCFramework was added to the target '#{target_name}'")
+      end
+
+      # Remove the XCFramework from the Xcode project target if needed
+      # @param target_name [String] The target name to remove the XCFramework
+      def remove_xcframework_from_xcodeproj_target_if_needed(target_name: nil)
+        target_name ||= Core::Console::Argument::Handler.fetch(key: %i[xcframework target])
+        return if target_name.to_s.empty?
+
+        Core::Console::Logger.important(message: "Removing the XCFramework from the target '#{target_name}'")
+        xcodeproj = Xcodeproj.xcodeproj
+        xcodeproj_target = Xcodeproj.xcodeproj_target_by_target_name(xcodeproj:, target_name:)
+        Xcodeproj.remove_xcframework(xcodeproj:, xcodeproj_target:, xcframework_path: Xcodeproj.xcframework_relative_path)
+
+        xcodeproj.save
+        Core::Console::Logger.success(message: "The XCFramework was removed from the target '#{target_name}'")
       end
     end
   end

--- a/lib/core/utils/swift/xcframework.rb
+++ b/lib/core/utils/swift/xcframework.rb
@@ -22,12 +22,12 @@ module SecureKeys
           end
         end
         generate_key_xcframework
-        add_xcframework_to_xcodeproj_target_if_needed
       end
 
-      def replace_xcframework_in_xcodeproj
-        remove_xcframework_from_xcodeproj_target_if_needed
-        add_xcframework_to_xcodeproj_target_if_needed
+      # Configure the XCFramework to the Xcode project
+      def configure_xcframework_to_xcodeproj
+        remove_xcframework_from_xcodeproj_target_if_needed if Globals.replace_xcframework?
+        add_xcframework_to_xcodeproj_target_if_needed if Globals.replace_xcframework? || Globals.add_xcframework?
       end
 
       private

--- a/lib/core/utils/swift/xcodeproj.rb
+++ b/lib/core/utils/swift/xcodeproj.rb
@@ -42,14 +42,27 @@ module SecureKeys
       # Get the Xcodeproj
       # @return [Xcodeproj] The Xcodeproj
       def xcodeproj
-        ::Xcodeproj::Project.open(SecureKeys::Globals.xcodeproj_path)
+        ::Xcodeproj::Project.open(Globals.xcodeproj_path)
+      end
+
+      # Remove all references to SecureKeys.xcframework from the Xcodeproj
+      # @param xcodeproj [Xcodeproj::Project] The Xcodeproj to remove the XCFramework
+      # @param xcodeproj_target [Xcodeproj::Project::Object::PBXNativeTarget] The target where the XCFramework is linked
+      # @param xcframework_path [String] The XCFramework path to remove
+      def remove_xcframework(xcodeproj:, xcodeproj_target:, xcframework_path:)
+        xcframework_filename = File.basename(xcframework_path)
+
+        remove_xcframework_from_build_phase(xcodeproj_target:, xcframework_filename:)
+        remove_xcframework_file_references(xcodeproj:, xcframework_filename:)
+        remove_xcframework_from_groups(xcodeproj:, xcframework_filename:)
+        remove_xcframework_from_search_paths(xcodeproj_target:, xcframework_filename:)
       end
 
       # Get the XCFramework relative path
       # @return [Pathname] The XCFramework relative path
       def xcframework_relative_path
-        Pathname.new(SecureKeys::Globals.secure_keys_xcframework_path)
-                .relative_path_from(Pathname.new(SecureKeys::Globals.xcodeproj_path).dirname)
+        Pathname.new(Globals.secure_keys_xcframework_path)
+                .relative_path_from(Pathname.new(Globals.xcodeproj_path).dirname)
       end
 
       # Check if the Xcode project has the secure keys XCFramework
@@ -60,8 +73,61 @@ module SecureKeys
           target.frameworks_build_phase.files.any? do |file|
             return false if file.file_ref.nil?
 
-            file.file_ref.path.include?(SecureKeys::Globals.secure_keys_xcframework_path)
+            file.file_ref.path.include?(Globals.secure_keys_xcframework_path)
           end
+        end
+      end
+
+      # Remove the XCFramework from the "Link Binary With Libraries" build phase
+      # @param xcodeproj_target [Xcodeproj::Project::Object::PBXNativeTarget] The target where the XCFramework is linked
+      # @param xcframework_filename [String] The XCFramework filename to remove
+      def remove_xcframework_from_build_phase(xcodeproj_target:, xcframework_filename:)
+        build_phase_files = xcodeproj_target.frameworks_build_phase.files.select do |file|
+          file.file_ref&.path&.include?(xcframework_filename)
+        end
+
+        build_phase_files.each do |file|
+          file.remove_from_project
+          Core::Console::Logger.verbose(message: "Removed #{xcframework_filename} from Link Binary With Libraries in target #{xcodeproj_target.name}")
+        end
+      end
+
+      # Remove the XCFramework from the file references
+      # @param xcodeproj [Xcodeproj::Project] The Xcodeproj to remove the XCFramework
+      # @param xcframework_filename [String] The XCFramework filename to remove
+      def remove_xcframework_file_references(xcodeproj:, xcframework_filename:)
+        file_references = xcodeproj.files.select { |file| file.path&.include?(xcframework_filename) }
+        file_references.each do |file_ref|
+          file_ref.remove_from_project
+          Core::Console::Logger.verbose(message: "Removed #{xcframework_filename} file reference")
+        end
+
+        # Ensure no orphaned references remain
+        xcodeproj.objects.select { |obj| obj.isa == 'PBXFileReference' && obj.path&.include?(xcframework_filename) }.each(&:remove_from_project)
+        xcodeproj.objects.select { |obj| obj.isa == 'PBXBuildFile' && obj.file_ref&.path&.include?(xcframework_filename) }.each(&:remove_from_project)
+      end
+
+      # Remove the XCFramework from groups (e.g., Frameworks Group)
+      # @param xcodeproj [Xcodeproj::Project] The Xcodeproj to remove the XCFramework
+      # @param xcframework_filename [String] The XCFramework filename to remove
+      def remove_xcframework_from_groups(xcodeproj:, xcframework_filename:)
+        frameworks_group = xcodeproj.frameworks_group
+        group_references = frameworks_group.files.select { |file| file.path&.include?(xcframework_filename) }
+
+        group_references.each do |file_ref|
+          frameworks_group.remove_reference(file_ref)
+          Core::Console::Logger.verbose(message: "Removed #{xcframework_filename} from Frameworks group")
+        end
+      end
+
+      # Remove the XCFramework from FRAMEWORK_SEARCH_PATHS
+      # @param xcodeproj_target [Xcodeproj::Project::Object::PBXNativeTarget] The target where the XCFramework is linked
+      # @param xcframework_filename [String] The XCFramework filename to remove
+      def remove_xcframework_from_search_paths(xcodeproj_target:, xcframework_filename:)
+        xcodeproj_target.build_configurations.each do |config|
+          framework_search_paths = config.build_settings['FRAMEWORK_SEARCH_PATHS'] || []
+          new_search_paths = framework_search_paths.reject { |path| path.include?(xcframework_filename) }
+          config.build_settings['FRAMEWORK_SEARCH_PATHS'] = new_search_paths unless framework_search_paths == new_search_paths
         end
       end
     end

--- a/lib/keys.rb
+++ b/lib/keys.rb
@@ -5,13 +5,14 @@ require_relative './core/generator'
 require_relative './core/globals/globals'
 require_relative './core/console/logger'
 require_relative './core/console/arguments/parser'
+require_relative './core/utils/swift/xcframework'
 
 module SecureKeys
   def self.run
     # Configure the argument parser
     Core::Console::Argument::Parser.new
-    return Core::Console::Logger.important(message: 'Skipping the generation of the SecureKeys XCFramework') unless Globals.generate_xcframework?
 
+    # Generate the keys
     Core::Generator.new.generate
   end
 end

--- a/lib/keys.rb
+++ b/lib/keys.rb
@@ -1,85 +1,16 @@
 #!/usr/bin/env ruby
 
-require_relative './core/utils/extensions/kernel'
+require_relative './core/generator'
 require_relative './core/globals/globals'
-require_relative './core/environment/ci'
-require_relative './core/environment/keychain'
-require_relative './core/utils/swift/writer'
-require_relative './core/utils/swift/package'
-require_relative './core/utils/swift/swift'
-require_relative './core/utils/swift/xcframework'
-require_relative './core/utils/openssl/cipher'
+require_relative './core/console/logger'
 require_relative './core/console/arguments/parser'
 
 module SecureKeys
-  class Generator
-    private
+  def self.run
+    # Configure the argument parser
+    Core::Console::Argument::Parser.new
+    return Core::Console::Logger.important(message: 'Skipping the generation of the SecureKeys XCFramework') unless Globals.generate_xcframework?
 
-    attr_accessor :cipher, :secrets_source, :secret_keys, :mapped_keys
-
-    public
-
-    def initialize
-      # Configure the argument parser
-      SecureKeys::Core::Console::Argument::Parser.new
-
-      puts "🔔 You're using a custom delimiter '#{SecureKeys::Globals.key_delimiter}'" unless SecureKeys::Globals.key_delimiter.eql?(SecureKeys::Globals.default_key_delimiter)
-      puts "🔔 You're using a custom key access identifier '#{SecureKeys::Globals.key_access_identifier}'" unless SecureKeys::Globals.key_access_identifier.eql?(SecureKeys::Globals.default_key_access_identifier)
-
-      # Configure cipher
-      self.cipher = SecureKeys::OpenSSL::Cipher.new
-
-      # Configure the secret source based on the environment
-      if SecureKeys::Globals.ci?
-        self.secrets_source = SecureKeys::Core::Environment::CI.new
-      else
-        self.secrets_source = SecureKeys::Core::Environment::Keychain.new
-      end
-
-      # Define the keys that we want to map
-      self.secret_keys = secrets_source.fetch(key: SecureKeys::Globals.key_access_identifier)
-                                       .to_s
-                                       .split(SecureKeys::Globals.key_delimiter)
-                                       .map(&:strip)
-
-      # Add the keys that we want to map
-      self.mapped_keys = secret_keys.map do |key|
-        encrypted_data = cipher.encrypt(value: secrets_source.fetch(key:))
-        # Convert the first key chart to downcase
-        key[0] = key[0].downcase
-        { name: key, **encrypted_data }
-      end
-    end
-
-    def setup
-      pre_actions
-
-      package = SecureKeys::Swift::Package.new
-      package.generate
-
-      writer = SecureKeys::Swift::Writer.new(mapped_keys: mapped_keys,
-                                             secure_key_bytes: cipher.secure_key_bytes)
-      writer.write
-
-      xcframework = SecureKeys::Swift::XCFramework.new
-      xcframework.generate
-
-      post_actions
-    end
-
-    private
-
-    def pre_actions
-      # Remove the keys directory
-      system("rm -rf #{SecureKeys::Swift::KEYS_DIRECTORY}")
-    end
-
-    def post_actions
-      # Remove the keys directory
-      system("rm -rf #{SecureKeys::Swift::SWIFT_PACKAGE_DIRECTORY}")
-
-      # Remove the build directory
-      system("rm -rf #{SecureKeys::Swift::KEYS_DIRECTORY}/#{SecureKeys::Swift::BUILD_DIRECTORY}")
-    end
+    Core::Generator.new.generate
   end
 end

--- a/lib/keys.rb
+++ b/lib/keys.rb
@@ -1,5 +1,6 @@
 #!/usr/bin/env ruby
 
+require_relative './core/utils/extensions/kernel'
 require_relative './core/generator'
 require_relative './core/globals/globals'
 require_relative './core/console/logger'

--- a/spec/core/console/arguments/parser_spec.rb
+++ b/spec/core/console/arguments/parser_spec.rb
@@ -21,19 +21,40 @@ describe(SecureKeys::Core::Console::Argument::Parser) do
       'Usage: secure-keys [--options]',
       '',
       '-h, --help                       Use the provided commands to select the params',
-      '--add-xcframework-to-target TARGET',
-      'Add the xcframework to the target',
+      '--xcframework                Add the xcframework to the target',
       '-d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")',
+      '--[no-]generate              Generate the SecureKeys.xcframework',
       '-i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")',
       '--verbose                    Enable verbose mode (default: false)',
-      '-v, --version                    Show the secure-keys version',
-      '-x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)'
+      '-v, --version                    Show the secure-keys version'
     ]
 
     # when
     %w[-h --help].each do |option|
       output_lines = `./bin/secure-keys #{option}`.split("\n")
                                                   .map(&:strip)
+
+      # then
+      expect(output_lines).to(eq(expected_help))
+    end
+  end
+
+  it('should be the XCFramework help information from terminal output') do
+    # given
+    expected_help = [
+      'Usage: secure-keys --xcframework [--options]',
+      '',
+      '-h, --help                       Use the provided commands to select the params',
+      '--[no-]add                   Add the SecureKeys XCFramework to the Xcode project (default: true)',
+      '-t, --target TARGET              The target to add the xcframework',
+      '-r, --replace                    Replace the existing xcframework in the Xcode project (default: false)',
+      '-x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)'
+    ]
+
+    # when
+    %w[-h --help].each do |option|
+      output_lines = `./bin/secure-keys --xcframework #{option}`.split("\n")
+                                                                .map(&:strip)
 
       # then
       expect(output_lines).to(eq(expected_help))

--- a/spec/core/globals/globals_spec.rb
+++ b/spec/core/globals/globals_spec.rb
@@ -7,13 +7,9 @@ describe(SecureKeys::Globals) do
     SecureKeys::Core::Console::Argument::Handler.reset
 
     # Reset the environment variables
-    ENV['SECURE_KEYS_IDENTIFIER'] = nil
-    ENV['SECURE_KEYS_DELIMITER'] = nil
-    ENV['SECURE_KEYS_VERBOSE'] = nil
-    ENV['VERBOSE'] = nil
-    ENV['CI'] = nil
-    ENV['CIRCLECI'] = nil
-    ENV['GITHUB_ACTIONS'] = nil
+    %w[SECURE_KEYS_IDENTIFIER SECURE_KEYS_DELIMITER SECURE_KEYS_VERBOSE SECURE_KEYS_XCFRAMEWORK_REPLACE XCFRAMEWORK_REPLACE SECURE_KEYS_XCFRAMEWORK_ADD XCFRAMEWORK_ADD VERBOSE CI CIRCLECI GITHUB_ACTIONS SECURE_KEYS_GENERATE GENERATE].each do |key|
+      ENV.delete(key)
+    end
   end
 
   it('should be CI actived from environment') do
@@ -231,5 +227,209 @@ describe(SecureKeys::Globals) do
 
     # then
     expect(SecureKeys::Globals.verbose?).to(eq(expected_verbose))
+  end
+
+  it('should be enabled the replace xcframework from argument handler') do
+    # given
+    expected_replace = true
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.deep_merge(key: :xcframework,
+                                                            value: { replace: expected_replace })
+
+    # then
+    expect(SecureKeys::Globals.replace_xcframework?).to(eq(expected_replace))
+  end
+
+  it('should be enabled the replace xcframework from env variable (SECURE_KEYS_XCFRAMEWORK_REPLACE)') do
+    # given
+    expected_replace = true
+
+    # when
+    ENV['SECURE_KEYS_XCFRAMEWORK_REPLACE'] = expected_replace.to_s
+
+    # then
+    expect(SecureKeys::Globals.replace_xcframework?).to(eq(expected_replace))
+  end
+
+  it('should be enabled the replace xcframework from env variable (XCFRAMEWORK_REPLACE)') do
+    # given
+    expected_replace = true
+
+    # when
+    ENV['XCFRAMEWORK_REPLACE'] = expected_replace.to_s
+
+    # then
+    expect(SecureKeys::Globals.replace_xcframework?).to(eq(expected_replace))
+  end
+
+  it('should be disabled the replace xcframework from argument handler') do
+    # given
+    expected_replace = false
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.deep_merge(key: :xcframework,
+                                                            value: { replace: expected_replace })
+
+    # then
+    expect(SecureKeys::Globals.replace_xcframework?).to(eq(expected_replace))
+  end
+
+  it('should be disabled the replace xcframework from env variable (SECURE_KEYS_XCFRAMEWORK_REPLACE)') do
+    # given
+    expected_replace = false
+
+    # when
+    ENV['SECURE_KEYS_XCFRAMEWORK_REPLACE'] = expected_replace.to_s
+
+    # then
+    expect(SecureKeys::Globals.replace_xcframework?).to(eq(expected_replace))
+  end
+
+  it('should be disabled the replace xcframework from env variable (XCFRAMEWORK_REPLACE)') do
+    # given
+    expected_replace = false
+
+    # when
+    ENV['XCFRAMEWORK_REPLACE'] = expected_replace.to_s
+
+    # then
+    expect(SecureKeys::Globals.replace_xcframework?).to(eq(expected_replace))
+  end
+
+  it('should be enabled the add xcframework from argument handler') do
+    # given
+    expected_add = true
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.deep_merge(key: :xcframework,
+                                                            value: { add: expected_add })
+
+    # then
+    expect(SecureKeys::Globals.add_xcframework?).to(eq(expected_add))
+  end
+
+  it('should be enabled the add xcframework from env variable (SECURE_KEYS_XCFRAMEWORK_ADD)') do
+    # given
+    expected_add = true
+
+    # when
+    ENV['SECURE_KEYS_XCFRAMEWORK_ADD'] = expected_add.to_s
+
+    # then
+    expect(SecureKeys::Globals.add_xcframework?).to(eq(expected_add))
+  end
+
+  it('should be enabled the add xcframework from env variable (XCFRAMEWORK_ADD)') do
+    # given
+    expected_add = true
+
+    # when
+    ENV['XCFRAMEWORK_ADD'] = expected_add.to_s
+
+    # then
+    expect(SecureKeys::Globals.add_xcframework?).to(eq(expected_add))
+  end
+
+  it('should be disabled the add xcframework from argument handler') do
+    # given
+    expected_add = false
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.deep_merge(key: :xcframework,
+                                                            value: { add: expected_add })
+
+    # then
+    expect(SecureKeys::Globals.add_xcframework?).to(eq(expected_add))
+  end
+
+  it('should be disabled the add xcframework from env variable (SECURE_KEYS_XCFRAMEWORK_ADD)') do
+    # given
+    expected_add = false
+
+    # when
+    ENV['SECURE_KEYS_XCFRAMEWORK_ADD'] = expected_add.to_s
+
+    # then
+    expect(SecureKeys::Globals.add_xcframework?).to(eq(expected_add))
+  end
+
+  it('should be disabled the add xcframework from env variable (XCFRAMEWORK_ADD)') do
+    # given
+    expected_add = false
+
+    # when
+    ENV['XCFRAMEWORK_ADD'] = expected_add.to_s
+
+    # then
+    expect(SecureKeys::Globals.add_xcframework?).to(eq(expected_add))
+  end
+
+  it('should be enabled the generate xcframework from argument handler') do
+    # given
+    expected_generate = true
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.set(key: :generate,
+                                                     value: expected_generate)
+
+    # then
+    expect(SecureKeys::Globals.generate_xcframework?).to(eq(expected_generate))
+  end
+
+  it('should be enabled the generate xcframework from env variable (SECURE_KEYS_GENERATE)') do
+    # given
+    expected_generate = true
+
+    # when
+    ENV['SECURE_KEYS_GENERATE'] = expected_generate.to_s
+
+    # then
+    expect(SecureKeys::Globals.generate_xcframework?).to(eq(expected_generate))
+  end
+
+  it('should be enabled the generate xcframework from env variable (GENERATE)') do
+    # given
+    expected_generate = true
+
+    # when
+    ENV['GENERATE'] = expected_generate.to_s
+
+    # then
+    expect(SecureKeys::Globals.generate_xcframework?).to(eq(expected_generate))
+  end
+
+  it('should be disabled the generate xcframework from argument handler') do
+    # given
+    expected_generate = false
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.set(key: :generate,
+                                                     value: expected_generate)
+
+    # then
+    expect(SecureKeys::Globals.generate_xcframework?).to(eq(expected_generate))
+  end
+
+  it('should be disabled the generate xcframework from env variable (SECURE_KEYS_GENERATE)') do
+    # given
+    expected_generate = false
+
+    # when
+    ENV['SECURE_KEYS_GENERATE'] = expected_generate.to_s
+
+    # then
+    expect(SecureKeys::Globals.generate_xcframework?).to(eq(expected_generate))
+  end
+
+  it('should be disabled the generate xcframework from env variable (GENERATE)') do
+    # given
+    expected_generate = false
+
+    # when
+    ENV['GENERATE'] = expected_generate.to_s
+
+    # then
+    expect(SecureKeys::Globals.generate_xcframework?).to(eq(expected_generate))
   end
 end

--- a/spec/core/utils/extensions/string/camelize_spec.rb
+++ b/spec/core/utils/extensions/string/camelize_spec.rb
@@ -1,0 +1,135 @@
+require 'core/utils/extensions/string/camelize'
+
+describe Camelize do
+  it('should convert a string to camel case format') do
+    # given
+    word = 'hello world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert an snake case string to camel case format') do
+    # given
+    snake_case_word = 'hello_world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = snake_case_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a kebab case string to camel case format') do
+    # given
+    kebab_case_word = 'hello-world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = kebab_case_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with multiple spaces to camel case format') do
+    # given
+    spaced_word = 'hello   world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = spaced_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with multiple underscores to camel case format') do
+    # given
+    underscored_word = 'hello___world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = underscored_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with multiple dashes to camel case format') do
+    # given
+    dashed_word = 'hello---world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = dashed_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with multiple mixed separators to camel case format') do
+    # given
+    mixed_word = 'hello -_ world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = mixed_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with uppercase letters to camel case format') do
+    # given
+    uppercase_word = 'HELLO_WORLD'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = uppercase_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with uppercase letters and mixed separators to camel case format') do
+    # given
+    mixed_word = 'HELLO -_ WORLD'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = mixed_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a string with uppercase letters and lowercase letters to camel case format') do
+    # given
+    mixed_word = 'HELLO -_ world'
+    expected_camelized_word = 'helloWorld'
+
+    # when
+    camelized_word = mixed_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+
+  it('should convert a upper camel case string to camel case format') do
+    # given
+    mixed_word = 'HelloTheWorld'
+    expected_camelized_word = 'helloTheWorld'
+
+    # when
+    camelized_word = mixed_word.camelize
+
+    # then
+    expect(camelized_word).to(eq(expected_camelized_word))
+  end
+end

--- a/spec/core/utils/xcodeproj_spec.rb
+++ b/spec/core/utils/xcodeproj_spec.rb
@@ -8,7 +8,7 @@ describe(SecureKeys::Swift::Xcodeproj) do
     SecureKeys::Core::Console::Argument::Handler.reset
 
     # reset the env variable
-    ENV['SECURE_KEYS_XCODEPROJ'] = nil
+    ENV['SECURE_KEYS_XCFRAMEWORK_XCODEPROJ'] = nil
   end
 
   it('should find the xcodeproj from env variables') do
@@ -18,7 +18,7 @@ describe(SecureKeys::Swift::Xcodeproj) do
 
     # when
     # define the env variable
-    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
+    ENV['SECURE_KEYS_XCFRAMEWORK_XCODEPROJ'] = expected_xcodeproj_path
     xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
 
     # then
@@ -33,7 +33,7 @@ describe(SecureKeys::Swift::Xcodeproj) do
 
     # when
     # define the argument handler
-    SecureKeys::Core::Console::Argument::Handler.set(key: :xcodeproj, value: expected_xcodeproj_path)
+    SecureKeys::Core::Console::Argument::Handler.deep_merge(key: :xcframework, value: { xcodeproj: expected_xcodeproj_path })
     xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
 
     # then
@@ -48,7 +48,7 @@ describe(SecureKeys::Swift::Xcodeproj) do
 
     # when
     # define the env variable
-    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
+    ENV['SECURE_KEYS_XCFRAMEWORK_XCODEPROJ'] = expected_xcodeproj_path
     xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
     xcodeproj_target = SecureKeys::Swift::Xcodeproj.xcodeproj_target_by_target_name(xcodeproj:,
                                                                                     target_name: expected_target_name)
@@ -66,7 +66,7 @@ describe(SecureKeys::Swift::Xcodeproj) do
 
     # when
     # define the env variable
-    ENV['SECURE_KEYS_XCODEPROJ'] = expected_xcodeproj_path
+    ENV['SECURE_KEYS_XCFRAMEWORK_XCODEPROJ'] = expected_xcodeproj_path
     xcodeproj = SecureKeys::Swift::Xcodeproj.xcodeproj
 
     # then

--- a/spec/helpers/arguments/handler.rb
+++ b/spec/helpers/arguments/handler.rb
@@ -9,6 +9,7 @@ module SecureKeys
           def self.reset
             @arguments = {
               delimiter: nil,
+              generate: false,
               identifier: nil,
               verbose: false,
             }

--- a/spec/helpers/arguments/handler.rb
+++ b/spec/helpers/arguments/handler.rb
@@ -5,13 +5,6 @@ module SecureKeys
     module Console
       module Argument
         class Handler
-          # Set the value of the key
-          # @param key [Symbol] the key to be updated
-          # @param value [String] the value to be updated
-          def self.set(key:, value:)
-            @arguments[key.to_sym] = value
-          end
-
           # Reset the arguments to initial values
           def self.reset
             @arguments = {


### PR DESCRIPTION
### Description

This PR improved the interaction when adding / replacing the `SecureKeys.xcframework` to an xcode project.

- Added more global methods to handle the framework code.
- Added `Camelize` extension to improve the String generation.
- Added tests for differents modules.

Also, updated the xcframework generation adding the `--add` and `--replace` CLI arguments.

e.g

```bash
secure-keys --xcframework --add
```

```bash
secure-keys --xcframework --replace
```

### Medias (if needed)

<img width="1003" alt="image" src="https://github.com/user-attachments/assets/6981aee4-e6c3-45a9-88ce-9082cdeb33cd" />

### Testplan

- [x] I tested this change on my local environment.
- [x] I ran the unit tests.

### Checklist

- [x] I added tests for this change.
- [x] I checked the code style and run the linter.
- [x] I added necessary documentation (if applicable).
