### PR TITLE
Handle CI environment from terminal

### DIFF
--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -9,6 +9,7 @@ module SecureKeys
 
           # Configure the default arguments
           @arguments = {
+            ci: false,
             delimiter: nil,
             generate: true,
             identifier: nil,

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -30,14 +30,15 @@ module SecureKeys
               exit(0)
             end
 
-            on('--xcframework', 'Add the xcframework to the target') do
-              XCFramework::Parser.new
-            end
-
+            on('--ci', TrueClass, 'Enable CI mode (default: false)')
             on('-d', '--delimiter DELIMITER', String, "The delimiter to use for the key access (default: \"#{Globals.default_key_delimiter}\")")
             on('--[no-]generate', TrueClass, 'Generate the SecureKeys.xcframework')
             on('-i', '--identifier IDENTIFIER', String, "The identifier to use for the key access (default: \"#{Globals.default_key_access_identifier}\")")
             on('--verbose', TrueClass, 'Enable verbose mode (default: false)')
+
+            on('--xcframework', 'Add the xcframework to the target') do
+              XCFramework::Parser.new
+            end
 
             on('-v', '--version', 'Show the secure-keys version') do
               puts "secure-keys version: v#{SecureKeys::VERSION}"

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -29,20 +29,17 @@ module SecureKeys
               puts self
               exit(0)
             end
-
             on('--ci', TrueClass, 'Enable CI mode (default: false)')
             on('-d', '--delimiter DELIMITER', String, "The delimiter to use for the key access (default: \"#{Globals.default_key_delimiter}\")")
             on('--[no-]generate', TrueClass, 'Generate the SecureKeys.xcframework')
             on('-i', '--identifier IDENTIFIER', String, "The identifier to use for the key access (default: \"#{Globals.default_key_access_identifier}\")")
             on('--verbose', TrueClass, 'Enable verbose mode (default: false)')
-
-            on('--xcframework', 'Add the xcframework to the target') do
-              XCFramework::Parser.new
-            end
-
             on('-v', '--version', 'Show the secure-keys version') do
               puts "secure-keys version: v#{SecureKeys::VERSION}"
               exit(0)
+            end
+            on('--xcframework', 'Add the xcframework to the target') do
+              XCFramework::Parser.new
             end
           end
 

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -16,7 +16,7 @@ module SecureKeys
       # Check for Jenkins, Travis CI, ... environment variables
       %w[JENKINS_HOME JENKINS_URL TRAVIS CI APPCENTER_BUILD_ID TEAMCITY_VERSION GO_PIPELINE_NAME bamboo_buildKey GITLAB_CI XCS TF_BUILD GITHUB_ACTION GITHUB_ACTIONS BITRISE_IO BUDDY CODEBUILD_BUILD_ARN].any? do |current|
         ENV[current].to_s.to_boolean
-      end || Core::Console::Argument::Handler.fetch(key: :ci)
+      end || Core::Console::Argument::Handler.fetch(key: :ci).to_s.to_boolean
     end
 
     # Check if the current build is running on CircleCI

--- a/lib/core/globals/globals.rb
+++ b/lib/core/globals/globals.rb
@@ -16,7 +16,7 @@ module SecureKeys
       # Check for Jenkins, Travis CI, ... environment variables
       %w[JENKINS_HOME JENKINS_URL TRAVIS CI APPCENTER_BUILD_ID TEAMCITY_VERSION GO_PIPELINE_NAME bamboo_buildKey GITLAB_CI XCS TF_BUILD GITHUB_ACTION GITHUB_ACTIONS BITRISE_IO BUDDY CODEBUILD_BUILD_ARN].any? do |current|
         ENV[current].to_s.to_boolean
-      end
+      end || Core::Console::Argument::Handler.fetch(key: :ci)
     end
 
     # Check if the current build is running on CircleCI

--- a/spec/core/console/arguments/parser_spec.rb
+++ b/spec/core/console/arguments/parser_spec.rb
@@ -21,12 +21,13 @@ describe(SecureKeys::Core::Console::Argument::Parser) do
       'Usage: secure-keys [--options]',
       '',
       '-h, --help                       Use the provided commands to select the params',
-      '--xcframework                Add the xcframework to the target',
+      '--ci                         Enable CI mode (default: false)',
       '-d, --delimiter DELIMITER        The delimiter to use for the key access (default: ",")',
       '--[no-]generate              Generate the SecureKeys.xcframework',
       '-i, --identifier IDENTIFIER      The identifier to use for the key access (default: "secure-keys")',
       '--verbose                    Enable verbose mode (default: false)',
-      '-v, --version                    Show the secure-keys version'
+      '-v, --version                    Show the secure-keys version',
+      '--xcframework                Add the xcframework to the target'
     ]
 
     # when

--- a/spec/core/globals/globals_spec.rb
+++ b/spec/core/globals/globals_spec.rb
@@ -65,6 +65,19 @@ describe(SecureKeys::Globals) do
     end
   end
 
+  it('should be CI actived from argument handler') do
+    # given
+    expected_ci = true
+
+    # when
+    SecureKeys::Core::Console::Argument::Handler.set(key: :ci,
+                                                     value: expected_ci)
+
+    # then
+    expect(SecureKeys::Globals.ci?).to(eq(expected_ci))
+    expect(SecureKeys::Globals.ci?).to(eq(expected_ci.to_s.to_boolean))
+  end
+
   it('should be the default access key value') do
     # given
     expected_access_key = SecureKeys::Globals.default_key_access_identifier

--- a/spec/core/globals/globals_spec.rb
+++ b/spec/core/globals/globals_spec.rb
@@ -65,7 +65,7 @@ describe(SecureKeys::Globals) do
     end
   end
 
-  it('should be CI actived from argument handler') do
+  it('should be CI activated from argument handler') do
     # given
     expected_ci = true
 

--- a/spec/helpers/arguments/handler.rb
+++ b/spec/helpers/arguments/handler.rb
@@ -8,6 +8,7 @@ module SecureKeys
           # Reset the arguments to initial values
           def self.reset
             @arguments = {
+              ci: false,
               delimiter: nil,
               generate: false,
               identifier: nil,


### PR DESCRIPTION
### Description

This PR added the `--ci` option to handle the environment from terminal.

- Ordered the terminal options.

#### Usage

```bash
secure-keys --ci
```

### Medias (if needed)

- None.

### Testplan

- [x] I tested this change on my local environment.
- [x] I ran the unit tests.

### Checklist

- [x] I added tests for this change.
- [x] I checked the code style and run the linter.
- [x] I added necessary documentation (if applicable).
