### PR TITLE
Add automatic Bumped version PR / Publish gem

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -77,7 +77,6 @@ jobs:
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"
-          assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
           title: "Bumped version to v${{ steps.release.outputs.version }}"
           add-paths: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -69,40 +69,17 @@ jobs:
           bundle install
           bundle config set frozen true
 
-      - name: Commit and Push changes
-        if: steps.release.outputs.version != ''
-        env:
-          VERSION: ${{ steps.release.outputs.version }}
-        run: |
-          git config user.name 'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add lib/version.rb README.md Gemfile.lock
-          git commit -m "feat(version): Bumped version to v$VERSION"
-          git push
-
-  open-pull-request:
-    needs: bump-version
-    if: contains(github.ref, 'refs/heads/release/')
-    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
-
-    permissions:
-      contents: write
-      pull-requests: write
-
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_PAT }}
-
       - uses: peter-evans/create-pull-request@v7
+        if: steps.release.outputs.version != ''
         with:
           token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
+          commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
-          title: "Bumped version to v${{ needs.bump-version.outputs.version }}"
+          title: "Bumped version to v${{ steps.release.outputs.version }}"
           body: |
             ### Description
 
-            Bumped version to v${{ needs.bump-version.outputs.version }}.
+            Bumped version to v${{ steps.release.outputs.version }}.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -71,9 +73,11 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         if: steps.release.outputs.version != ''
         with:
+          token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"
+          assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
           title: "Bumped version to v${{ steps.release.outputs.version }}"
           add-paths: |

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -97,7 +97,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_PAT }}
-          branch: ${{ github.head_ref }}
+          branch: ${{ github.head_ref || github.ref_name }}
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
           title: "Bumped version to v${{ needs.bump-version.outputs.version }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,6 +19,9 @@ jobs:
   bump-version:
     if: contains(github.ref, 'refs/heads/release/')
     runs-on: ${{ vars.RUNS_ON || 'macos-latest' }}
+    outputs:
+      version: ${{ steps.release.outputs.version }}
+
     steps:
       - uses: actions/checkout@v4
         with:
@@ -76,3 +79,29 @@ jobs:
           git add lib/version.rb README.md Gemfile.lock
           git commit -m "feat(version): Bumped version to v$VERSION"
           git push
+
+  open-pull-request:
+    needs: bump-version
+    if: contains(github.ref, 'refs/heads/release/')
+    runs-on: ${{ vars.RUNS_ON || 'ubuntu-latest' }}
+
+    permissions:
+      contents: write
+      pull-requests: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
+
+      - uses: peter-evans/create-pull-request@v7
+        with:
+          token: ${{ secrets.GH_PAT }}
+          branch: ${{ github.head_ref }}
+          assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
+          reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
+          title: "Bumped version to v${{ needs.bump-version.outputs.version }}"
+          body: |
+            ### Description
+
+            Bumped version to v${{ needs.bump-version.outputs.version }}.

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -71,14 +71,9 @@ jobs:
         with:
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
-          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
-          add-paths: |
-            README.md
-            lib/version.rb
-            Gemfile.lock
           title: "Bumped version to v${{ steps.release.outputs.version }}"
           body: |
             ### Description

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -69,7 +69,6 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         if: steps.release.outputs.version != ''
         with:
-          token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
           author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,8 +25,6 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_PAT }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -73,7 +71,6 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         if: steps.release.outputs.version != ''
         with:
-          token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -25,6 +25,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GH_PAT }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -71,6 +73,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         if: steps.release.outputs.version != ''
         with:
+          token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,13 +19,10 @@ jobs:
   bump-version:
     if: contains(github.ref, 'refs/heads/release/')
     runs-on: ${{ vars.RUNS_ON || 'macos-latest' }}
-    outputs:
-      version: ${{ steps.release.outputs.version }}
+    permissions: write-all
 
     steps:
       - uses: actions/checkout@v4
-        with:
-          token: ${{ secrets.GH_PAT }}
 
       - uses: ruby/setup-ruby@v1
         with:
@@ -75,7 +72,7 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
-          author: ${{ vars.AUTHOR || 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>' }}
+          author: ${{ github.actor }} <${{ github.actor }}@users.noreply.github.com>
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -75,9 +75,14 @@ jobs:
           token: ${{ secrets.GH_PAT }}
           base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
+          author: ${{ vars.AUTHOR || 'github-actions[bot] <github-actions[bot]@users.noreply.github.com>' }}
           commit-message: "feat(version): Bumped version to v${{ steps.release.outputs.version }}"
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
+          add-paths: |
+            README.md
+            lib/version.rb
+            Gemfile.lock
           title: "Bumped version to v${{ steps.release.outputs.version }}"
           body: |
             ### Description

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -19,7 +19,9 @@ jobs:
   bump-version:
     if: contains(github.ref, 'refs/heads/release/')
     runs-on: ${{ vars.RUNS_ON || 'macos-latest' }}
-    permissions: write-all
+    permissions:
+      contents: write
+      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -75,6 +77,10 @@ jobs:
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}
           title: "Bumped version to v${{ steps.release.outputs.version }}"
+          add-paths: |
+            README.md
+            lib/version.rb
+            Gemfile.lock
           body: |
             ### Description
 

--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -97,6 +97,7 @@ jobs:
       - uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GH_PAT }}
+          base: ${{ vars.BASE_BRANCH || 'main' }}
           branch: ${{ github.head_ref || github.ref_name }}
           assignees: ${{ vars.ASSIGNEES || 'derian-cordoba' }}
           reviewers: ${{ vars.REVIEWERS || 'derian-cordoba' }}

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -1,0 +1,36 @@
+name: Publish gem
+
+on:
+  pull_request:
+    types:
+      - closed
+
+jobs:
+  publish-gem:
+    if: github.event.pull_request.merged == 'true' && (contains(github.ref, 'refs/heads/release/'))
+    runs-on: ${{ vars.RUNS_ON || 'macos-latest' }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - uses: ruby/setup-ruby@v1
+
+      - name: Install dependencies
+        run: |
+          bundle install
+
+      - name: Configure credentials
+        env:
+          GEM_HOST_API_KEY: ${{ secrets.GEM_HOST_API_KEY }}
+        run: |
+          gem_directory="$HOME/.gem"
+          mkdir -p $gem_directory
+          touch $gem_directory/credentials
+          chmod 0600 $gem_directory/credentials
+          printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $gem_directory/credentials
+
+      - name: Publish gem
+        run: |
+          gem build *.gemspec
+          gem push *.gem

--- a/.github/workflows/publish-gem.yml
+++ b/.github/workflows/publish-gem.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   publish-gem:
-    if: github.event.pull_request.merged == 'true' && (contains(github.ref, 'refs/heads/release/'))
+    if: github.event.pull_request.merged == true && (contains(github.ref, 'refs/heads/release/'))
     runs-on: ${{ vars.RUNS_ON || 'macos-latest' }}
 
     steps:


### PR DESCRIPTION
### Description

This PR introduces automated workflows to handle version bumping and gem publishing for releases on `release/*` branches.

## 🚀 Automatic Gem Publish on Merge

- **Trigger:** When a pull request into a `release/*` branch is **closed and merged**.
- **Action:** Builds and pushes the gem to [RubyGems](https://rubygems.org/).
- **Steps:**
  - Installs dependencies.
  - Configures RubyGems credentials using `GEM_HOST_API_KEY`.
  - Builds the `.gem` file from `.gemspec`.
  - Publishes it using `gem push`.

## 📌 Benefits

- Eliminates manual steps in the release workflow.
- Ensures consistent versioning and changelog tracking.
- Fully automates the publishing process upon merge.

### Medias (if needed)

- None.

### Testplan

- [ ] I tested this change on my local environment.
- [ ] I ran the unit tests.

### Checklist

- [ ] I added tests for this change.
- [x] I checked the code style and run the linter.
- [ ] I added necessary documentation (if applicable).
