### PR TITLE
Scan validation feature

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -102,6 +102,7 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
+  arm64-darwin-25
 
 DEPENDENCIES
   bump

--- a/README.md
+++ b/README.md
@@ -1,140 +1,162 @@
-<div style="display: flex; gap: 10px; padding-bottom: 20px;">
-  <img src="https://img.shields.io/badge/version-1.1.7-cyan" alt="SecureKeys version">
+# Secure Key Generator for iOS Projects
 
-  <img src="https://img.shields.io/badge/iOS-^13.0-blue" alt="iOS version 13.0">
+`secure-keys` is a Ruby CLI that generates a `SecureKeys.xcframework` for iOS apps. It reads secret values from macOS Keychain on local machines or environment variables in CI, encrypts those values with AES-256-GCM, writes a Swift API, builds an XCFramework, and optionally adds that framework to an Xcode target.
 
-  <img src="https://img.shields.io/badge/Ruby-^3.3.6-red" alt="Ruby version 3.3.6">
+## Requirements
 
-</div>
+- macOS 11.0 or later
+- Ruby 3.3 or later
+- Xcode command line tools
+- iOS 13.0 or later
 
-# Secure Key Generator for iOS projects
+## Installation
 
-Utility to generate a `xcframework` for handling secure keys in iOS projects.
-
-### Prerequisites
-
-- Ruby 3.3.6 or higher
-- iOS 13.0 or higher
-- macOS 11.0 or higher
-
-### Installation
-
-You can install the `SecureKeys` utility using Homebrew using the following command:
+Install with Homebrew:
 
 ```bash
 brew tap derian-cordoba/secure-keys
-
 brew install derian-cordoba/secure-keys/secure-keys
 ```
 
-For more details, you can visit the [homebrew-secure-keys](https://github.com/derian-cordoba/homebrew-secure-keys) repository.
-
-Another way, you can install the `SecureKeys` utility using `gem` command:
+Install with RubyGems:
 
 ```bash
 gem install secure-keys
 ```
 
-If you using `bundler` you can add the `secure-keys` gem to the `Gemfile`:
+Install with Bundler:
 
 ```ruby
 gem 'secure-keys'
 ```
 
-Then, you can install the gem using:
-
 ```bash
 bundle install
 ```
 
-For more information about the gem, you can visit the [secure-keys](https://rubygems.org/gems/secure-keys) page.
+## Quick Start
 
-## Usage
+From an iOS project root:
 
-As first step, you need to determine the keys that you want to use in your iOS project. You can define the keys from Keychain or env variables.
+```bash
+security add-generic-password -a "secure-keys" -s "secure-keys" -w "apiKey,githubToken"
+security add-generic-password -a "secure-keys" -s "apiKey" -w "your-api-key"
+security add-generic-password -a "secure-keys" -s "githubToken" -w "your-github-token"
 
-The source is determined by the current platform **local or CI / cloud** using the `CI` environment variable.
+secure-keys
+```
 
-If the `CI` environment variable is set to `true`, the keys are read from the environment variables. Otherwise, the keys are read from the Keychain.
+The command creates `.secure-keys/SecureKeys.xcframework`.
 
-You can configure your keys like this:
+Use the generated framework from Swift:
 
-### From Keychain
+```swift
+import SecureKeys
 
-1. You need to define the `secure-keys` record in the Keychain with the key name and the key value.
+let apiKey = SecureKey.apiKey.decryptedValue
+let githubToken = key(for: .githubToken)
+```
 
-The value for this key should be all the key names separated by a comma.
+## How Secret Generation Works
+
+`secure-keys` does not create third-party API keys for providers such as GitHub, Firebase, Stripe, or AWS. Those secrets must be created in their owning service first.
+
+The tool generates an iOS framework that contains encrypted copies of the secret values you provide:
+
+1. Resolve the secret source:
+   - Local runs use macOS Keychain unless CI mode is enabled.
+   - CI runs use environment variables.
+2. Read the configured list of secret names.
+3. Read each secret value by name.
+4. Generate a random AES-256-GCM key for this build.
+5. Encrypt each secret value.
+6. Write a Swift `SecureKey` enum with encrypted byte arrays.
+7. Build `.secure-keys/SecureKeys.xcframework`.
+8. Remove temporary Swift package files.
+
+## Local Configuration With Keychain
+
+The default Keychain service and account identifier is `secure-keys`.
+
+Store the list of secret names:
 
 ```bash
 security add-generic-password -a "secure-keys" -s "secure-keys" -w "githubToken,apiKey"
 ```
 
-If you want to use another keychain identifier, you can define an env variable named `SECURE_KEYS_IDENTIFIER` to set the keychain identifier.
+Store each secret value under the same Keychain service:
 
 ```bash
-export SECURE_KEYS_IDENTIFIER="your-keychain-identifier"
-
-security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "$SECURE_KEYS_IDENTIFIER" -w "githubToken,apiKey"
-```
-
-2. You can add new keys using the `security` command.
-
-```bash
+security add-generic-password -a "secure-keys" -s "githubToken" -w "your-github-token"
 security add-generic-password -a "secure-keys" -s "apiKey" -w "your-api-key"
 ```
 
-Using custom keychain identifier:
+Use a custom Keychain identifier:
 
 ```bash
+export SECURE_KEYS_IDENTIFIER="my-app-secrets"
+
+security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "$SECURE_KEYS_IDENTIFIER" -w "githubToken,apiKey"
+security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "githubToken" -w "your-github-token"
 security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "apiKey" -w "your-api-key"
 ```
 
-### Environment variables
+Use a custom delimiter:
 
-1. You can define the keys in the `.env` file or export the keys as environment variables.
+```bash
+export SECURE_KEYS_DELIMITER="|"
+security add-generic-password -a "secure-keys" -s "secure-keys" -w "githubToken|apiKey"
+```
+
+## CI Configuration With Environment Variables
+
+CI mode is enabled automatically when common CI variables are present, including `CI=true` and `GITHUB_ACTIONS=true`. You can also force it:
+
+```bash
+secure-keys --ci
+```
+
+Set the list of secret names in `SECURE_KEYS_IDENTIFIER`:
 
 ```bash
 export SECURE_KEYS_IDENTIFIER="github-token,api_key,firebaseToken"
+```
 
+Set each secret value as an environment variable. Secret names are looked up exactly first, then normalized by converting `-` to `_` and uppercasing.
+
+```bash
 export GITHUB_TOKEN="your-github-token"
 export API_KEY="your-api-key"
 export FIREBASETOKEN="your-firebase-token"
 ```
 
-> The key names are formatted in uppercase and replace the `-` with `_`.
+The `SECURE_KEYS_` prefix is also supported for secret values:
 
-> [!IMPORTANT]
-> If you want to use another demiliter, you can define an env variable named `SECURE_KEYS_DELIMITER` to set the delimiter.
+```bash
+export SECURE_KEYS_API_KEY="your-api-key"
+```
+
+You can store the list in a dedicated environment variable instead:
+
+```bash
+export CUSTOM_SECRET_LIST="github-token,api_key"
+secure-keys --ci --identifier CUSTOM_SECRET_LIST
+```
+
+Use a custom delimiter in CI:
 
 ```bash
 export SECURE_KEYS_DELIMITER="|"
-
 export SECURE_KEYS_IDENTIFIER="github-token|api_key|firebaseToken"
 ```
 
-### Ruby script
-
-To generate the `SecureKeys.xcframework` use the `secure-keys` command in the iOS project root directory.
-
-Using global gem:
-
-```bash
-secure-keys
-```
-
-Using bundler:
-
-```bash
-bundle exec secure-keys
-```
-
-To get more information about the command, you can use the `--help` option.
+## CLI Reference
 
 ```bash
 secure-keys --help
+```
 
-# Output
-
+```text
 Usage: secure-keys [--options]
 
     -h, --help                       Use the provided commands to select the params
@@ -147,172 +169,356 @@ Usage: secure-keys [--options]
         --xcframework                Add the xcframework to the target
 ```
 
-To avoid defining the `SECURE_KEYS_IDENTIFIER` and `SECURE_KEYS_DELIMITER` env variables, you can use the `--identifier` and `--delimiter` options.
+Examples:
 
 ```bash
-secure-keys --identifier "your-keychain-or-env-variable-identifier" --delimiter "|"
+secure-keys
+secure-keys --verbose
+secure-keys --ci --identifier CUSTOM_SECRET_LIST
+secure-keys --identifier "my-app-secrets" --delimiter "|"
+secure-keys -i "my-app-secrets" -d "|"
 ```
 
-Also, you can use the short options:
+## Xcode Integration
+
+Generate the framework only:
 
 ```bash
-secure-keys -i "your-keychain-or-env-variable-identifier" -d "|"
+secure-keys
 ```
 
-### iOS project
-
-Within the iOS project, you can use the `SecureKeys` target dependency like:
-
-```swift
-import SecureKeys
-
-// Using key directly in the code
-let apiKey = SecureKey.apiKey.decryptedValue
-
-// Using key from `SecureKey` enum
-let someKey: String = key(for: .someKey)
-
-// Alternative way to use key from `SecureKey` enum
-let someKey: String = key(.someKey)
-
-// Using raw value from `SecureKey` enum
-let apiKey: SecureKey = "apiKey".secretKey
-
-// Using raw value from `SecureKey` enum with decrypted value
-let apiKey: String = "apiKey".secretKey.decryptedValue
-
-// Using `key` method to get the key
-let apiKey: String = .key(for: .apiKey)
-```
-
-## How to install the `SecureKeys.xcframework` in the iOS project
-
-### Automatically
-
-> [!IMPORTANT]
-> You can see more information about the command using the `--help` option.
-
-```bash
-secure-keys --xcframework --help
-
-# Output
-Usage: secure-keys --xcframework [--options]
-
-    -h, --help                       Use the provided commands to select the params
-        --[no-]add                   Add the SecureKeys XCFramework to the Xcode project (default: true)
-    -t, --target TARGET              The target to add the xcframework
-    -r, --replace                    Replace the existing xcframework in the Xcode project (default: false)
-    -x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)
-```
-
-From the `secure-keys` command, you can use the `--xcframework` option to add the `SecureKeys.xcframework` to the iOS project.
+Generate and add the framework to an Xcode target:
 
 ```bash
 secure-keys --xcframework --target "YourTargetName" --add
 ```
 
-If you want to add the `SecureKeys.xcframework` to an iOS that already contains the `SecureKeys` source code, you can use the `--replace` option.
+Replace an existing framework reference:
 
 ```bash
 secure-keys --xcframework --target "YourTargetName" --replace
 ```
 
-> [!IMPORTANT]
-> If you don't need to generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
+Add an already generated framework without rebuilding:
 
 ```bash
 secure-keys --no-generate --xcframework --target "YourTargetName"
 ```
 
-Also, you can specify your Xcode project path using the `--xcodeproj` option.
+Select a project explicitly:
 
 ```bash
-secure-keys --xcframework --target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
+secure-keys --xcframework --target "YourTargetName" --xcodeproj "/path/to/YourProject.xcodeproj"
 ```
 
-> [!IMPORTANT]
-> By default, the xcodeproj path would be the first found Xcode project.
-
-If you don't want to use the CLI options, you can configure some env variable to interact with the `secure-keys` command.
+The same options can be configured with environment variables:
 
 ```bash
-# e.g (Large version)
 export SECURE_KEYS_XCFRAMEWORK_TARGET="YourTargetName"
 export SECURE_KEYS_XCFRAMEWORK_ADD=true
-export SECURE_KEYS_XCFRAMEWORK_REPLACE=true
-export SECURE_KEYS_XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
+export SECURE_KEYS_XCFRAMEWORK_REPLACE=false
+export SECURE_KEYS_XCFRAMEWORK_XCODEPROJ="/path/to/YourProject.xcodeproj"
 
-# e.g (Short version)
-export XCFRAMEWORK_TARGET="YourTargetName"
-export XCFRAMEWORK_ADD=true
-export XCFRAMEWORK_REPLACE=true
-export XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
-
-# Run the command
 secure-keys --xcframework
 ```
 
-### Manually
-
-1. From the iOS project, click on the project target, select the `General` tab, and scroll down to the `Frameworks, Libraries, and Embedded Content` section.
-
-![Project Target](/docs/assets/add-xcframework-to-ios-project/first-step.png)
-
-2. Click on the `Add Other...` button and click on the `Add Files...` option.
-
-![Add Files](/docs/assets/add-xcframework-to-ios-project/second-step.png)
-
-3. Navigate to the `keys` directory and select the `SecureKeys.xcframework` folder.
-
-![Select SecureKeys.xcframework](/docs/assets/add-xcframework-to-ios-project/third-step.png)
-
-> Now the `SecureKeys.xcframework` is added to the iOS project.
-
-![Select SecureKeys.xcframework](/docs/assets/add-xcframework-to-ios-project/third-step-result.png)
-
-4. Click on the `Build settings` tab and search for the `Search Paths` section.
-
-![Search Paths](/docs/assets/add-xcframework-to-ios-project/fourth-step.png)
-
-> Add the path to the `SecureKeys.xcframework` in the `Framework Search Paths` section.
+Short environment variable names are also supported:
 
 ```bash
-$(inherited)
-$(SRCROOT)/.secure-keys
+export XCFRAMEWORK_TARGET="YourTargetName"
+export XCFRAMEWORK_ADD=true
+export XCFRAMEWORK_REPLACE=false
+export XCFRAMEWORK_XCODEPROJ="/path/to/YourProject.xcodeproj"
 ```
 
-## How it works
+### Manual Xcode Setup
 
-The process when the script is executed is:
+If you do not use `--xcframework`, add the framework manually:
 
-1. Create a `.secure-keys` directory.
-2. Create a temporary `Swift Package` in the `.secure-keys` directory.
-3. Copy the `SecureKeys` source code to the temporary `Swift Package`.
+1. Open the Xcode project target.
+2. Open `General`.
+3. Add `.secure-keys/SecureKeys.xcframework` to `Frameworks, Libraries, and Embedded Content`.
+4. Open `Build Settings`.
+5. Add `$(SRCROOT)/.secure-keys` to `Framework Search Paths`.
 
-   ```swift
-   public enum SecureKey {
+## Swift API
 
-       // MARK: - Cases
+The generated framework exposes `SecureKey`, `key(for:)`, `key(_:)`, and a `String.secretKey` helper.
 
-       case apiKey
-       case someKey
-       case unknown
+```swift
+import SecureKeys
 
-       // MARK: - Properties
+let apiKey = SecureKey.apiKey.decryptedValue
+let githubToken = key(for: .githubToken)
+let sameGithubToken = key(.githubToken)
+let keyFromString: SecureKey = "apiKey".secretKey
+let valueFromString = "apiKey".secretKey.decryptedValue
+let staticValue = String.key(for: .apiKey)
+```
 
-       /// The decrypted value of the key
-       public var decryptedValue: String {
-           switch self {
-               case .apiKey: [1, 2, 4].decrypt(key: [248, 53, 26], iv: [148, 55, 47], tag: [119, 81])
-               case .someKey: [1, 2, 4].decrypt(key: [248, 53, 26], iv: [148, 55, 47], tag: [119, 81])
-               case .unknown: fatalError("Unknown key \(rawValue)")
-           }
-       }
-   }
-   ```
+Generated key names are camelized for Swift enum cases:
 
-4. Generate the `SecureKeys.xcframework` using the temporary `Swift Package`.
-5. Remove the temporary `Swift Package`.
+```text
+api-key      -> SecureKey.apiKey
+githubToken  -> SecureKey.githubToken
+```
+
+## Output Files
+
+The main output is:
+
+```text
+.secure-keys/SecureKeys.xcframework
+```
+
+Temporary Swift package and build files are created under `.secure-keys` during generation and removed after the framework is built.
+
+## Security Notes
+
+- Do not commit `.secure-keys/SecureKeys.xcframework` unless your release process intentionally requires it.
+- Do not commit `.env` files or raw secret values.
+- Treat app-bundled secrets as obfuscation, not as a perfect security boundary. A determined attacker can inspect a shipped app binary.
+- Prefer server-side secret usage for highly sensitive credentials.
+- Use environment-specific keys for development, staging, and production.
+- Rotate keys regularly and revoke leaked credentials immediately.
+
+## Secret Scanning and Validation
+
+`secure-keys` ships both a CLI and a Ruby API for validating individual secret values and scanning source files or git diffs for accidentally exposed credentials.
+
+### CLI
+
+Scan the current directory:
+
+```bash
+secure-keys validate scan
+```
+
+Scan a specific path:
+
+```bash
+secure-keys validate scan ./src
+```
+
+Scan only staged git changes (useful as a pre-commit hook):
+
+```bash
+secure-keys validate scan --staged
+```
+
+Save the report as JSON:
+
+```bash
+secure-keys validate scan --output report.json
+```
+
+Override the file extensions and exclusions:
+
+```bash
+secure-keys validate scan --extensions .rb,.swift,.go --excludes vendor,tmp,build
+```
+
+Enable verbose output:
+
+```bash
+secure-keys validate scan --verbose
+```
+
+Full option reference:
+
+```text
+Usage: secure-keys validate scan [path] [--options]
+
+    -h, --help          Show help for the scan subcommand
+        --staged        Scan staged git changes instead of a directory (default: false)
+    -o, --output FILE   Save the scan report as JSON to FILE
+        --extensions    Comma-separated file extensions to scan (e.g. .rb,.swift)
+        --excludes      Comma-separated directory names to exclude from the scan
+        --verbose       Enable verbose output (default: false)
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Scan completed with no findings |
+| `1` | One or more secrets were detected |
+
+### Validating a Secret
+
+`SecureKeys::Validation::Validator` checks a single value against a set of security rules and returns a `ValidationResult`.
+
+```ruby
+require 'validation/validator'
+
+validator = SecureKeys::Validation::Validator.new
+result    = validator.validate(key: :api_key, value: ENV['API_KEY'])
+
+puts result.summary          # ✅ api_key — no issues  /  ❌ api_key — 2 issue(s)
+puts result.valid?           # true / false
+puts result.severity_level   # :ok | :warning | :error | :critical
+result.print                 # formatted report to stdout
+```
+
+Available validation options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `check_entropy` | Boolean | `false` | Flag low-entropy (repetitive) values |
+| `allow_production` | Boolean | `false` | Skip the production-key warning |
+| `warn_on_pattern` | Boolean | `false` | Emit an informational notice when a pattern matches |
+
+```ruby
+result = validator.validate(
+  key: :stripe_key,
+  value: ENV['STRIPE_KEY'],
+  options: { check_entropy: true, warn_on_pattern: true }
+)
+```
+
+Detect the type of a secret value:
+
+```ruby
+info = validator.detect_type(value: 'ghp_abc...')
+# => { type: :github_token, description: "GitHub Personal Access Token", severity: :high, ... }
+```
+
+Get provider-specific security recommendations:
+
+```ruby
+validator.recommendations(key: :githubToken)
+# => ["Use GitHub Personal Access Tokens with minimal required scopes", ...]
+```
+
+### Scanning Files for Exposed Secrets
+
+`SecureKeys::Validation::Scanner` scans source files or git diffs for credentials that match any of the 25+ built-in patterns.
+
+Scan a directory:
+
+```ruby
+require 'validation/scanner'
+
+scanner = SecureKeys::Validation::Scanner.new
+result  = scanner.scan_directory(path: '.')
+
+puts result.clean?        # true if no findings
+puts result.files_count   # number of files scanned
+
+result.findings.each { |f| puts f.to_s }
+result.print if !result.clean?
+```
+
+Scan only staged git changes (useful in a pre-commit hook):
+
+```ruby
+result = scanner.scan_git_diff                    # staged only (default)
+result = scanner.scan_git_diff(staged_only: false) # staged + unstaged
+```
+
+Customize the scan at initialization or per call:
+
+```ruby
+scanner = SecureKeys::Validation::Scanner.new(
+  options: {
+    extensions: ['.rb', '.swift', '.go'],
+    excludes:   ['vendor', 'node_modules', '.git'],
+    max_depth:  5
+  }
+)
+```
+
+Filter findings by severity:
+
+```ruby
+result.by_severity(severity: :critical).each { |f| puts f.to_s }
+```
+
+### Detected Patterns
+
+The scanner recognizes the following secret types out of the box:
+
+| Pattern | Severity |
+|---|---|
+| GitHub personal / OAuth / App / refresh token | high |
+| AWS access key ID | critical |
+| AWS secret access key | critical |
+| Google Cloud API key | high |
+| Google OAuth token | high |
+| Stripe secret key (live / test) | critical |
+| Stripe publishable / restricted key | medium / high |
+| Slack bot / app / webhook token | high / medium |
+| JWT token | medium |
+| PEM / RSA / EC / OpenSSH private key | critical |
+| Generic API key assignment | medium |
+| Generic secret / password assignment | medium |
+| Firebase API key | medium |
+| Twilio API key / Account SID | high / low |
+| SendGrid API key | high |
+| Mailchimp API key | medium |
+| Square access token | high |
+| PayPal Braintree access token | critical |
+| Heroku API key | high |
+| Base64-encoded secret | low |
+| Suspicious assignment (catch-all) | low |
+
+### Validation Configuration
+
+All thresholds can be overridden with environment variables. Both the bare name and the `SECURE_KEYS_` prefix are supported.
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `SECURE_KEYS_API_KEY_LENGTH` | `20` | Minimum API key length |
+| `SECURE_KEYS_TOKEN_LENGTH` | `20` | Minimum token length |
+| `SECURE_KEYS_SECRET_LENGTH` | `16` | Minimum secret length |
+| `SECURE_KEYS_PASSWORD_LENGTH` | `12` | Minimum password length |
+| `SECURE_KEYS_KEY_LENGTH` | `16` | Minimum generic key length |
+| `SECURE_KEYS_SCAN_EXTENSIONS` | `.swift,.rb,.py,.js,...` | Comma-separated file extensions to scan |
+| `SECURE_KEYS_SCAN_EXCLUDES` | `.git,node_modules,Pods,...` | Comma-separated names to exclude |
+| `SECURE_KEYS_MAX_SCAN_DEPTH` | `10` | Maximum directory traversal depth |
+| `SECURE_KEYS_MIN_ENTROPY_THRESHOLD` | `3.0` | Shannon entropy threshold for `check_entropy` |
+
+## Troubleshooting
+
+`Error fetching the key from Keychain`
+
+Verify the Keychain service, account, and identifier values. For the default configuration, the list must be stored with account `secure-keys` and service `secure-keys`.
+
+`Error fetching the key from ENV variables`
+
+Verify CI mode is enabled and that each configured key has a matching environment variable. For example, `github-token` maps to `GITHUB_TOKEN`.
+
+`xcodebuild` fails
+
+Verify Xcode command line tools are installed and selected:
+
+```bash
+xcode-select -p
+```
+
+`SecureKeys.xcframework` is not found by Xcode
+
+Verify `$(SRCROOT)/.secure-keys` is present in `Framework Search Paths` and that the framework is attached to the correct target.
+
+## Development
+
+Install dependencies:
+
+```bash
+bundle install
+```
+
+Run the test suite:
+
+```bash
+bundle exec rspec
+```
+
+Run the local CLI:
+
+```bash
+bundle exec ./bin/secure-keys --help
+```
 
 ## License
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,136 +1,162 @@
 # Secure Key Generator for iOS Projects
 
-A utility to securely generate and manage keys for iOS projects using `xcframework`. This tool helps to safely store and retrieve sensitive keys such as API tokens and access credentials in your iOS app, with support for both local and CI environments.
+`secure-keys` is a Ruby CLI that generates a `SecureKeys.xcframework` for iOS apps. It reads secret values from macOS Keychain on local machines or environment variables in CI, encrypts those values with AES-256-GCM, writes a Swift API, builds an XCFramework, and optionally adds that framework to an Xcode target.
 
-## Prerequisites
+## Requirements
 
-Before you begin, ensure that your development environment meets the following prerequisites:
-
-- **Ruby 3.3.6 or higher**
-- **iOS 13.0 or higher**
+- macOS 11.0 or later
+- Ruby 3.3 or later
+- Xcode command line tools
+- iOS 13.0 or later
 
 ## Installation
 
-There are multiple ways to install the `SecureKeys` utility:
-
-### Option 1: Install via Homebrew
-
-You can install the `SecureKeys` utility using [Homebrew](https://brew.sh/) with the following commands:
+Install with Homebrew:
 
 ```bash
 brew tap derian-cordoba/secure-keys
-
 brew install derian-cordoba/secure-keys/secure-keys
 ```
 
-For more details, you can visit the [homebrew-secure-keys](https://github.com/derian-cordoba/homebrew-secure-keys) repository.
-
-### Option 2: Install via RubyGems
-
-Alternatively, you can install the utility using RubyGems:
+Install with RubyGems:
 
 ```bash
 gem install secure-keys
 ```
 
-### Option 3: Install via Bundler
+Install with Bundler:
 
-If you're using Bundler to manage your Ruby dependencies, add the gem to your `Gemfile`:
-
-```bash
+```ruby
 gem 'secure-keys'
 ```
-
-Then, run:
 
 ```bash
 bundle install
 ```
 
-For more details, you can visit the [homebrew-secure-keys](https://github.com/derian-cordoba/homebrew-secure-keys) repository.
+## Quick Start
 
-## Usage
+From an iOS project root:
 
-### Step 1: Define Your Keys
+```bash
+security add-generic-password -a "secure-keys" -s "secure-keys" -w "apiKey,githubToken"
+security add-generic-password -a "secure-keys" -s "apiKey" -w "your-api-key"
+security add-generic-password -a "secure-keys" -s "githubToken" -w "your-github-token"
 
-First, determine the keys you want to use in your iOS project. The keys can be sourced either from your Keychain or environment variables. The source of keys is determined by the `CI` environment variable.
+secure-keys
+```
 
-- If `CI=true`, keys will be read from environment variables.
-- If `CI=false` or not set, keys will be read from the Keychain.
+The command creates `.secure-keys/SecureKeys.xcframework`.
 
-You can configure your keys as follows:
+Use the generated framework from Swift:
 
-#### From Keychain
+```swift
+import SecureKeys
 
-1. Define the secure-keys record in your Keychain with the key names and values. The value should be a comma-separated list of keys.
+let apiKey = SecureKey.apiKey.decryptedValue
+let githubToken = key(for: .githubToken)
+```
+
+## How Secret Generation Works
+
+`secure-keys` does not create third-party API keys for providers such as GitHub, Firebase, Stripe, or AWS. Those secrets must be created in their owning service first.
+
+The tool generates an iOS framework that contains encrypted copies of the secret values you provide:
+
+1. Resolve the secret source:
+   - Local runs use macOS Keychain unless CI mode is enabled.
+   - CI runs use environment variables.
+2. Read the configured list of secret names.
+3. Read each secret value by name.
+4. Generate a random AES-256-GCM key for this build.
+5. Encrypt each secret value.
+6. Write a Swift `SecureKey` enum with encrypted byte arrays.
+7. Build `.secure-keys/SecureKeys.xcframework`.
+8. Remove temporary Swift package files.
+
+## Local Configuration With Keychain
+
+The default Keychain service and account identifier is `secure-keys`.
+
+Store the list of secret names:
 
 ```bash
 security add-generic-password -a "secure-keys" -s "secure-keys" -w "githubToken,apiKey"
 ```
 
-If you need to use a custom Keychain identifier, set the `SECURE_KEYS_IDENTIFIER` environment variable:
+Store each secret value under the same Keychain service:
 
 ```bash
-export SECURE_KEYS_IDENTIFIER="your-keychain-identifier"
-
-security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "$SECURE_KEYS_IDENTIFIER" -w "githubToken,apiKey"
-```
-
-2. Add new keys to the Keychain as needed:
-
-```bash
+security add-generic-password -a "secure-keys" -s "githubToken" -w "your-github-token"
 security add-generic-password -a "secure-keys" -s "apiKey" -w "your-api-key"
 ```
 
-Or with a custom Keychain identifier:
+Use a custom Keychain identifier:
 
 ```bash
+export SECURE_KEYS_IDENTIFIER="my-app-secrets"
+
+security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "$SECURE_KEYS_IDENTIFIER" -w "githubToken,apiKey"
+security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "githubToken" -w "your-github-token"
 security add-generic-password -a "$SECURE_KEYS_IDENTIFIER" -s "apiKey" -w "your-api-key"
 ```
 
-#### From Environment Variables
+Use a custom delimiter:
 
-You can define the keys in the `.env` file or export the keys as environment variables.
+```bash
+export SECURE_KEYS_DELIMITER="|"
+security add-generic-password -a "secure-keys" -s "secure-keys" -w "githubToken|apiKey"
+```
+
+## CI Configuration With Environment Variables
+
+CI mode is enabled automatically when common CI variables are present, including `CI=true` and `GITHUB_ACTIONS=true`. You can also force it:
+
+```bash
+secure-keys --ci
+```
+
+Set the list of secret names in `SECURE_KEYS_IDENTIFIER`:
 
 ```bash
 export SECURE_KEYS_IDENTIFIER="github-token,api_key,firebaseToken"
+```
+
+Set each secret value as an environment variable. Secret names are looked up exactly first, then normalized by converting `-` to `_` and uppercasing.
+
+```bash
 export GITHUB_TOKEN="your-github-token"
 export API_KEY="your-api-key"
 export FIREBASETOKEN="your-firebase-token"
 ```
 
-> Important: Key names should be formatted in uppercase with `-` replaced by `_` (e.g., `github-token` becomes `GITHUB_TOKEN`).
+The `SECURE_KEYS_` prefix is also supported for secret values:
 
-##### Custom Delimiter
+```bash
+export SECURE_KEYS_API_KEY="your-api-key"
+```
 
-If you prefer a delimiter other than the default comma, you can set a custom delimiter using the `SECURE_KEYS_DELIMITER` environment variable:
+You can store the list in a dedicated environment variable instead:
+
+```bash
+export CUSTOM_SECRET_LIST="github-token,api_key"
+secure-keys --ci --identifier CUSTOM_SECRET_LIST
+```
+
+Use a custom delimiter in CI:
 
 ```bash
 export SECURE_KEYS_DELIMITER="|"
 export SECURE_KEYS_IDENTIFIER="github-token|api_key|firebaseToken"
 ```
 
-### Step 2: Generate the SecureKeys.xcframework
-
-After configuring your keys, generate the `SecureKeys.xcframework` by running the following command in your iOS project root directory:
-
-```bash
-secure-keys
-```
-
-Using Bundler:
-
-```bash
-bundle exec secure-keys
-```
-
-To get more information about the command, you can use the `--help` option.
+## CLI Reference
 
 ```bash
 secure-keys --help
+```
 
-# Output
-
+```text
 Usage: secure-keys [--options]
 
     -h, --help                       Use the provided commands to select the params
@@ -143,172 +169,357 @@ Usage: secure-keys [--options]
         --xcframework                Add the xcframework to the target
 ```
 
-To avoid defining the `SECURE_KEYS_IDENTIFIER` and `SECURE_KEYS_DELIMITER` env variables, you can use the `--identifier` and `--delimiter` options.
+Examples:
 
 ```bash
-secure-keys --identifier "your-keychain-or-env-variable-identifier" --delimiter "|"
+secure-keys
+secure-keys --verbose
+secure-keys --ci --identifier CUSTOM_SECRET_LIST
+secure-keys --identifier "my-app-secrets" --delimiter "|"
+secure-keys -i "my-app-secrets" -d "|"
 ```
 
-Also, you can use the short options:
+## Xcode Integration
+
+Generate the framework only:
 
 ```bash
-secure-keys -i "your-keychain-or-env-variable-identifier" -d "|"
+secure-keys
 ```
 
-### Step 3: Integrate SecureKeys.xcframework into Your iOS Project
-
-#### Automatically
-
-> [!IMPORTANT]
-> You can see more information about the command using the `--help` option.
-
-```bash
-secure-keys --xcframework --help
-
-# Output
-Usage: secure-keys --xcframework [--options]
-
-    -h, --help                       Use the provided commands to select the params
-        --[no-]add                   Add the SecureKeys XCFramework to the Xcode project (default: true)
-    -t, --target TARGET              The target to add the xcframework
-    -r, --replace                    Replace the existing xcframework in the Xcode project (default: false)
-    -x, --xcodeproj XCODEPROJ        The Xcode project path (default: the first found Xcode project)
-```
-
-From the `secure-keys` command, you can use the `--xcframework` option to add the `SecureKeys.xcframework` to the iOS project.
+Generate and add the framework to an Xcode target:
 
 ```bash
 secure-keys --xcframework --target "YourTargetName" --add
 ```
 
-If you want to add the `SecureKeys.xcframework` to an iOS that already contains the `SecureKeys` source code, you can use the `--replace` option.
+Replace an existing framework reference:
 
 ```bash
 secure-keys --xcframework --target "YourTargetName" --replace
 ```
 
-> [!IMPORTANT]
-> If you don't need to generate the `SecureKeys.xcframework` every time, you can use the `--no-generate` option.
+Add an already generated framework without rebuilding:
 
 ```bash
 secure-keys --no-generate --xcframework --target "YourTargetName"
 ```
 
-Also, you can specify your Xcode project path using the `--xcodeproj` option.
+Select a project explicitly:
 
 ```bash
-secure-keys --xcframework --target "YourTargetName" --xcodeproj "/path/to/your/project.xcodeproj"
+secure-keys --xcframework --target "YourTargetName" --xcodeproj "/path/to/YourProject.xcodeproj"
 ```
 
-> [!IMPORTANT]
-> By default, the xcodeproj path would be the first found Xcode project.
-
-If you don't want to use the CLI options, you can configure some env variable to interact with the `secure-keys` command.
+The same options can be configured with environment variables:
 
 ```bash
-# e.g (Large version)
 export SECURE_KEYS_XCFRAMEWORK_TARGET="YourTargetName"
 export SECURE_KEYS_XCFRAMEWORK_ADD=true
-export SECURE_KEYS_XCFRAMEWORK_REPLACE=true
-export SECURE_KEYS_XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
+export SECURE_KEYS_XCFRAMEWORK_REPLACE=false
+export SECURE_KEYS_XCFRAMEWORK_XCODEPROJ="/path/to/YourProject.xcodeproj"
 
-# e.g (Short version)
-export XCFRAMEWORK_TARGET="YourTargetName"
-export XCFRAMEWORK_ADD=true
-export XCFRAMEWORK_REPLACE=true
-export XCFRAMEWORK_XCODEPROJ="/path/to/your/project.xcodeproj"
-
-# Run the command
 secure-keys --xcframework
 ```
 
-#### Manually
-
-1. From the iOS project, click on the project target, select the `General` tab, and scroll down to the `Frameworks, Libraries, and Embedded Content` section.
-
-![Project Target](https://derian-cordoba.github.io/secure-keys/assets/add-xcframework-to-ios-project/first-step.png)
-
-2. Click on the `Add Other...` button and click on the `Add Files...` option.
-
-![Add Files](https://derian-cordoba.github.io/secure-keys/assets/add-xcframework-to-ios-project/second-step.png)
-
-3. Navigate to the `Securekeys` directory and select the `SecureKeys.xcframework` folder.
-
-![Select SecureKeys.xcframework](https://derian-cordoba.github.io/secure-keys/assets/add-xcframework-to-ios-project/third-step.png)
-
-> Now the `SecureKeys.xcframework` is added to the iOS project.
-
-![Select SecureKeys.xcframework](https://derian-cordoba.github.io/secure-keys/assets/add-xcframework-to-ios-project/third-step-result.png)
-
-4. Click on the `Build settings` tab and search for the `Search Paths` section.
-
-![Search Paths](https://derian-cordoba.github.io/secure-keys/assets/add-xcframework-to-ios-project/fourth-step.png)
-
-> Add the path to the `SecureKeys.xcframework` in the `Framework Search Paths` section.
+Short environment variable names are also supported:
 
 ```bash
-$(inherited)
-$(SRCROOT)/.secure-keys
+export XCFRAMEWORK_TARGET="YourTargetName"
+export XCFRAMEWORK_ADD=true
+export XCFRAMEWORK_REPLACE=false
+export XCFRAMEWORK_XCODEPROJ="/path/to/YourProject.xcodeproj"
 ```
 
-### Step 4: Use the Keys in Your Code
+### Manual Xcode Setup
 
-In your iOS code, you can now use the Keys framework to securely retrieve your keys:
+If you do not use `--xcframework`, add the framework manually:
+
+1. Open the Xcode project target.
+2. Open `General`.
+3. Add `.secure-keys/SecureKeys.xcframework` to `Frameworks, Libraries, and Embedded Content`.
+4. Open `Build Settings`.
+5. Add `$(SRCROOT)/.secure-keys` to `Framework Search Paths`.
+
+## Swift API
+
+The generated framework exposes `SecureKey`, `key(for:)`, `key(_:)`, and a `String.secretKey` helper.
 
 ```swift
 import SecureKeys
 
-// Using the key directly
 let apiKey = SecureKey.apiKey.decryptedValue
-
-// Accessing a key by enum case
-let someKey: String = key(for: .someKey)
-
-// Another way to access the key
-let someKey: String = key(.someKey)
-
-// Using the raw value to access the key
-let apiKey: SecureKey = "apiKey".secretKey
-
-// Accessing decrypted value from the raw key
-let apiKey: String = "apiKey".secretKey.decryptedValue
-
-// Using the `key` method to retrieve the key
-let apiKey: String = .key(for: .apiKey)
+let githubToken = key(for: .githubToken)
+let sameGithubToken = key(.githubToken)
+let keyFromString: SecureKey = "apiKey".secretKey
+let valueFromString = "apiKey".secretKey.decryptedValue
+let staticValue = String.key(for: .apiKey)
 ```
 
-## How It Works
+Generated key names are camelized for Swift enum cases:
 
-When the script is executed, it follows these steps:
+```text
+api-key      -> SecureKey.apiKey
+githubToken  -> SecureKey.githubToken
+```
 
-1. A `.secure-keys` directory is created.
-2. A temporary Swift Package is generated within the `.secure-keys` directory.
-3. The Keys source code is copied into the temporary Swift Package.
-4. The `SecureKeys.xcframework` is generated using the temporary Swift Package.
-5. The temporary Swift Package is removed.
+## Output Files
 
-```swift
-public enum SecureKey {
+The main output is:
 
-    // MARK: - Cases
+```text
+.secure-keys/SecureKeys.xcframework
+```
 
-    case apiKey
-    case someKey
-    case unknown
+Temporary Swift package and build files are created under `.secure-keys` during generation and removed after the framework is built.
 
-    // MARK: - Properties
+## Security Notes
 
-    /// The decrypted value of the key
-    public var decryptedValue: String {
-        switch self {
-            case .apiKey: [1, 2, 4].decrypt(key: [248, 53, 26], iv: [148, 55, 47], tag: [119, 81])
-            case .someKey: [1, 2, 4].decrypt(key: [248, 53, 26], iv: [148, 55, 47], tag: [119, 81])
-            case .unknown: fatalError("Unknown key \(rawValue)")
-        }
-    }
-}
+- Do not commit `.secure-keys/SecureKeys.xcframework` unless your release process intentionally requires it.
+- Do not commit `.env` files or raw secret values.
+- Treat app-bundled secrets as obfuscation, not as a perfect security boundary. A determined attacker can inspect a shipped app binary.
+- Prefer server-side secret usage for highly sensitive credentials.
+- Use environment-specific keys for development, staging, and production.
+- Rotate keys regularly and revoke leaked credentials immediately.
+
+## Secret Scanning and Validation
+
+`secure-keys` ships both a CLI and a Ruby API for validating individual secret values and scanning source files or git diffs for accidentally exposed credentials.
+
+### CLI
+
+Scan the current directory:
+
+```bash
+secure-keys validate scan
+```
+
+Scan a specific path:
+
+```bash
+secure-keys validate scan ./src
+```
+
+Scan only staged git changes (useful as a pre-commit hook):
+
+```bash
+secure-keys validate scan --staged
+```
+
+Save the report as JSON:
+
+```bash
+secure-keys validate scan --output report.json
+```
+
+Override the file extensions and exclusions:
+
+```bash
+secure-keys validate scan --extensions .rb,.swift,.go --excludes vendor,tmp,build
+```
+
+Enable verbose output:
+
+```bash
+secure-keys validate scan --verbose
+```
+
+Full option reference:
+
+```text
+Usage: secure-keys validate scan [path] [--options]
+
+    -h, --help          Show help for the scan subcommand
+        --staged        Scan staged git changes instead of a directory (default: false)
+    -o, --output FILE   Save the scan report as JSON to FILE
+        --extensions    Comma-separated file extensions to scan (e.g. .rb,.swift)
+        --excludes      Comma-separated directory names to exclude from the scan
+        --verbose       Enable verbose output (default: false)
+```
+
+Exit codes:
+
+| Code | Meaning |
+|---|---|
+| `0` | Scan completed with no findings |
+| `1` | One or more secrets were detected |
+
+### Validating a Secret
+
+`SecureKeys::Validation::Validator` checks a single value against a set of security rules and returns a `ValidationResult`.
+
+```ruby
+require 'validation/validator'
+
+validator = SecureKeys::Validation::Validator.new
+result    = validator.validate(key: :api_key, value: ENV['API_KEY'])
+
+puts result.summary          # ✅ api_key — no issues  /  ❌ api_key — 2 issue(s)
+puts result.valid?           # true / false
+puts result.severity_level   # :ok | :warning | :error | :critical
+result.print                 # formatted report to stdout
+```
+
+Available validation options:
+
+| Option | Type | Default | Description |
+|---|---|---|---|
+| `check_entropy` | Boolean | `false` | Flag low-entropy (repetitive) values |
+| `allow_production` | Boolean | `false` | Skip the production-key warning |
+| `warn_on_pattern` | Boolean | `false` | Emit an informational notice when a pattern matches |
+
+```ruby
+result = validator.validate(
+  key: :stripe_key,
+  value: ENV['STRIPE_KEY'],
+  options: { check_entropy: true, warn_on_pattern: true }
+)
+```
+
+Detect the type of a secret value:
+
+```ruby
+info = validator.detect_type(value: 'ghp_abc...')
+# => { type: :github_token, description: "GitHub Personal Access Token", severity: :high, ... }
+```
+
+Get provider-specific security recommendations:
+
+```ruby
+validator.recommendations(key: :githubToken)
+# => ["Use GitHub Personal Access Tokens with minimal required scopes", ...]
+```
+
+### Scanning Files for Exposed Secrets
+
+`SecureKeys::Validation::Scanner` scans source files or git diffs for credentials that match any of the 25+ built-in patterns.
+
+Scan a directory:
+
+```ruby
+require 'validation/scanner'
+
+scanner = SecureKeys::Validation::Scanner.new
+result  = scanner.scan_directory(path: '.')
+
+puts result.clean?        # true if no findings
+puts result.files_count   # number of files scanned
+
+result.findings.each { |f| puts f.to_s }
+result.print if !result.clean?
+```
+
+Scan only staged git changes (useful in a pre-commit hook):
+
+```ruby
+result = scanner.scan_git_diff                    # staged only (default)
+result = scanner.scan_git_diff(staged_only: false) # staged + unstaged
+```
+
+Customize the scan at initialization or per call:
+
+```ruby
+scanner = SecureKeys::Validation::Scanner.new(
+  options: {
+    extensions: ['.rb', '.swift', '.go'],
+    excludes:   ['vendor', 'node_modules', '.git'],
+    max_depth:  5
+  }
+)
+```
+
+Filter findings by severity:
+
+```ruby
+result.by_severity(severity: :critical).each { |f| puts f.to_s }
+```
+
+### Detected Patterns
+
+The scanner recognizes the following secret types out of the box:
+
+| Pattern | Severity |
+|---|---|
+| GitHub personal / OAuth / App / refresh token | high |
+| AWS access key ID | critical |
+| AWS secret access key | critical |
+| Google Cloud API key | high |
+| Google OAuth token | high |
+| Stripe secret key (live / test) | critical |
+| Stripe publishable / restricted key | medium / high |
+| Slack bot / app / webhook token | high / medium |
+| JWT token | medium |
+| PEM / RSA / EC / OpenSSH private key | critical |
+| Generic API key assignment | medium |
+| Generic secret / password assignment | medium |
+| Firebase API key | medium |
+| Twilio API key / Account SID | high / low |
+| SendGrid API key | high |
+| Mailchimp API key | medium |
+| Square access token | high |
+| PayPal Braintree access token | critical |
+| Heroku API key | high |
+| Base64-encoded secret | low |
+| Suspicious assignment (catch-all) | low |
+
+### Validation Configuration
+
+All thresholds can be overridden with environment variables. Both the bare name and the `SECURE_KEYS_` prefix are supported.
+
+| Environment variable | Default | Description |
+|---|---|---|
+| `SECURE_KEYS_API_KEY_LENGTH` | `20` | Minimum API key length |
+| `SECURE_KEYS_TOKEN_LENGTH` | `20` | Minimum token length |
+| `SECURE_KEYS_SECRET_LENGTH` | `16` | Minimum secret length |
+| `SECURE_KEYS_PASSWORD_LENGTH` | `12` | Minimum password length |
+| `SECURE_KEYS_KEY_LENGTH` | `16` | Minimum generic key length |
+| `SECURE_KEYS_SCAN_EXTENSIONS` | `.swift,.rb,.py,.js,...` | Comma-separated file extensions to scan |
+| `SECURE_KEYS_SCAN_EXCLUDES` | `.git,node_modules,Pods,...` | Comma-separated names to exclude |
+| `SECURE_KEYS_MAX_SCAN_DEPTH` | `10` | Maximum directory traversal depth |
+| `SECURE_KEYS_MIN_ENTROPY_THRESHOLD` | `3.0` | Shannon entropy threshold for `check_entropy` |
+
+## Troubleshooting
+
+`Error fetching the key from Keychain`
+
+Verify the Keychain service, account, and identifier values. For the default configuration, the list must be stored with account `secure-keys` and service `secure-keys`.
+
+`Error fetching the key from ENV variables`
+
+Verify CI mode is enabled and that each configured key has a matching environment variable. For example, `github-token` maps to `GITHUB_TOKEN`.
+
+`xcodebuild` fails
+
+Verify Xcode command line tools are installed and selected:
+
+```bash
+xcode-select -p
+```
+
+`SecureKeys.xcframework` is not found by Xcode
+
+Verify `$(SRCROOT)/.secure-keys` is present in `Framework Search Paths` and that the framework is attached to the correct target.
+
+## Development
+
+Install dependencies:
+
+```bash
+bundle install
+```
+
+Run the test suite:
+
+```bash
+bundle exec rspec
+```
+
+Run the local CLI:
+
+```bash
+bundle exec ./bin/secure-keys --help
 ```
 
 ## License
 
-This project is licensed under the MIT License. See the [License](LICENSE) file for more information.
+This project is licensed under the MIT [License](../LICENSE).

--- a/lib/core/console/arguments/fetchable.rb
+++ b/lib/core/console/arguments/fetchable.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Core
+    module Console
+      module Argument
+        # Shared fetch/set behaviour for argument handler classes.
+        # Include this module inside +class << self+ so the methods become
+        # class-level accessors that check the handler's own +arguments+ hash
+        # before falling back to environment variables.
+        #
+        # The including class must expose +arguments+ as a class-level reader
+        # (via +attr_reader :arguments+ inside +class << self+).
+        module Fetchable
+          # Fetch an argument value, falling back to SECURE_KEYS_<KEY>,
+          # then the bare <KEY> environment variable, then +default+.
+          #
+          # @param key [Symbol, Array<Symbol>] The argument key (or nested key path)
+          # @param default [Object] The value to return when nothing is found
+          # @return [Object] The resolved value
+          def fetch(key:, default: nil)
+            keys = Array(key).map(&:to_sym)
+            joined_keys = keys.join('_').upcase
+            arguments.dig(*keys) || ENV["SECURE_KEYS_#{joined_keys}"] || ENV[joined_keys] || default
+          end
+
+          # Update a single argument value
+          # @param key [Symbol] The argument key to update
+          # @param value [Object] The new value
+          # @return [void]
+          def set(key:, value:)
+            arguments[key.to_sym] = value
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/core/console/arguments/handler.rb
+++ b/lib/core/console/arguments/handler.rb
@@ -1,9 +1,13 @@
+require_relative 'fetchable'
+
 module SecureKeys
   module Core
     module Console
       module Argument
         class Handler
           class << self
+            include Fetchable
+
             attr_reader :arguments
           end
 
@@ -16,31 +20,11 @@ module SecureKeys
             verbose: false,
           }
 
-          # Fetch the argument value by key
-          # from CLI arguments or environment variables
-          #
-          # @param key [Array|Symbol] the argument key
-          # @param default [String] the default value
-          #
-          # @return [String] the argument value
-          def self.fetch(key:, default: nil)
-            keys = Array(key).map(&:to_sym)
-            joined_keys = keys.join('_').upcase
-            @arguments.dig(*keys) || ENV["SECURE_KEYS_#{joined_keys}"] || ENV[joined_keys] || default
-          end
-
-          # Set the value of the key
-          # @param key [Symbol] the key to be updated
-          # @param value [String] the value to be updated
-          def self.set(key:, value:)
-            @arguments[key.to_sym] = value
-          end
-
-          # Append the argument value by key
+          # Append a hash value into a nested key, initialising it when absent
           # @param key [Symbol] the argument key
-          # @param value [String] the argument value
+          # @param value [Hash] the hash to merge in
           def self.deep_merge(key:, value:)
-            @arguments[key.to_sym] ||= {} # Initialize the key if it doesn't exist
+            @arguments[key.to_sym] ||= {}
             @arguments[key.to_sym].merge!(value)
           end
         end

--- a/lib/core/console/arguments/parser.rb
+++ b/lib/core/console/arguments/parser.rb
@@ -15,6 +15,11 @@ module SecureKeys
             super('Usage: secure-keys [--options]')
             separator('')
 
+            # Route known subcommands before processing flags.
+            # Like --help and --version, subcommand handlers exit internally,
+            # so the generator is never reached.
+            route_subcommand!
+
             # Configure the argument parser
             configure!
             order!(into: Handler.arguments)
@@ -22,6 +27,27 @@ module SecureKeys
           end
 
           private
+
+          # Known positional subcommands mapped to their handler lambdas.
+          # Each lambda is expected to handle its own output and exit.
+          SUBCOMMANDS = {
+            'validate' => lambda {
+              require_relative '../../../validation/console/arguments/parser'
+              Validation::Console::Argument::Parser.new.execute
+            },
+          }.freeze
+
+          # Detect a known positional subcommand as the first ARGV token and delegate
+          # to its handler. Like --help and --version, the handler exits internally so
+          # the generator is never reached.
+          # @return [void]
+          def route_subcommand!
+            token = ARGV.first
+            return unless SUBCOMMANDS.key?(token)
+
+            ARGV.shift
+            SUBCOMMANDS[token].call
+          end
 
           # Configure the argument parser
           def configure!

--- a/lib/core/environment/ci.rb
+++ b/lib/core/environment/ci.rb
@@ -1,5 +1,7 @@
 #!/usr/bin/env ruby
 
+require_relative '../console/logger'
+
 module SecureKeys
   module Core
     module Environment
@@ -8,9 +10,20 @@ module SecureKeys
         # @param key [String] the key of the environment variable to fetch
         # @return [String] the value of the environment variable
         def fetch(key:)
-          ENV.fetch(key)
+          normalized_key = key.to_s.tr('-', '_').upcase
+
+          ENV[key.to_s] ||
+            ENV[normalized_key] ||
+            ENV["SECURE_KEYS_#{normalized_key}"] ||
+            inline_identifier_value(key)
         rescue StandardError
-          puts "❌ Error fetching the key: #{key} from ENV variables"
+          Core::Console::Logger.error(message: "Error fetching the key '#{key}' from ENV variables")
+        end
+
+        private
+
+        def inline_identifier_value(key)
+          key if key.to_s.include?(SecureKeys::Globals.key_delimiter)
         end
       end
     end

--- a/lib/core/generator.rb
+++ b/lib/core/generator.rb
@@ -40,8 +40,9 @@ module SecureKeys
       end
 
       def generate
+        pre_actions
+
         if Globals.generate_xcframework?
-          pre_actions
           generate_swift_package
           write_keys
           xcframework.generate

--- a/lib/core/generator.rb
+++ b/lib/core/generator.rb
@@ -40,16 +40,15 @@ module SecureKeys
       end
 
       def generate
-        pre_actions
-
         if Globals.generate_xcframework?
+          pre_actions
           generate_swift_package
           write_keys
           xcframework.generate
+          post_actions
         end
 
         xcframework.configure_xcframework_to_xcodeproj
-        post_actions if Globals.generate_xcframework?
       end
 
       private

--- a/lib/services/environment.rb
+++ b/lib/services/environment.rb
@@ -1,0 +1,38 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Services
+    module Environment
+      module_function
+
+      # Fetches the value of an environment variable with support for SecureKeys prefix
+      # @param key [Symbol] The environment variable key to fetch
+      # @param default [Object] The default value to return if the environment variable is not set
+      # @return [Object, nil] The value of the environment variable or the default value
+      def fetch(key:, default: nil)
+        formatted_key = key.to_s.upcase
+        ENV[formatted_key] || ENV["SECURE_KEYS_#{formatted_key}"] || default
+      end
+
+      # Fetches the integer value of an environment variable with support for SecureKeys prefix
+      # @param key [Symbol] The environment variable key to fetch
+      # @param default [Object] The default value to return if the environment variable is not set or cannot be converted to an integer
+      # @return [Integer, nil] The integer value of the environment variable or the default value
+      def integer(key:, default: nil)
+        value = fetch(key:, default:)
+        Integer(value)
+      rescue ArgumentError, TypeError
+        # Returns default if it's nil or integer, otherwise, force return nil
+        default.is_a?(Integer) || default.nil? ? default : nil
+      end
+
+      def decimal(key:, default: nil)
+        value = fetch(key:, default:)
+        Float(value)
+      rescue ArgumentError, TypeError
+        # Returns default if it's nil or float, otherwise, force return nil
+        default.is_a?(Float) || default.nil? ? default : nil
+      end
+    end
+  end
+end

--- a/lib/validation/actions/scan.rb
+++ b/lib/validation/actions/scan.rb
@@ -66,7 +66,7 @@ module SecureKeys
           Core::Console::Logger.message(message: separator)
 
           if result.clean?
-            Core::Console::Logger.success(message: '\t✅ No secrets found')
+            Core::Console::Logger.success(message: "\t✅ No secrets found")
           else
             print_severity_summary(result:)
             Core::Console::Logger.message(message: separator)

--- a/lib/validation/actions/scan.rb
+++ b/lib/validation/actions/scan.rb
@@ -1,0 +1,126 @@
+#!/usr/bin/env ruby
+
+require 'json'
+require_relative '../console/arguments/scan/handler'
+require_relative '../../core/console/logger'
+require_relative '../scanner'
+
+module SecureKeys
+  module Validation
+    module Actions
+      # Executes the `validate scan` action: runs the scanner, prints a formatted
+      # report to the console, optionally saves a JSON report, and exits with an
+      # appropriate code (0 = clean, 1 = findings present).
+      class Scan
+        # Run the scan, print the report, and exit
+        # @return [void]
+        def run
+          result = execute_scan
+          print_result(result:)
+          save_report(result:) if Console::Argument::Scan::Handler.fetch(key: :output)
+          exit(result.clean? ? 0 : 1)
+        end
+
+        private
+
+        # Build optional scanner overrides from CLI arguments via Handler.fetch
+        # @return [Hash] A sparse options hash (only keys explicitly provided by the user)
+        def scanner_options
+          options = {}
+
+          if (extensions = Console::Argument::Scan::Handler.fetch(key: :extensions))
+            options[:extensions] = extensions.split(',').map(&:strip)
+          end
+
+          if (excludes = Console::Argument::Scan::Handler.fetch(key: :excludes))
+            options[:excludes] = excludes.split(',').map(&:strip)
+          end
+
+          options
+        end
+
+        # Run the appropriate scan based on the --staged flag
+        # @return [ScanResult] The result of the scan
+        def execute_scan
+          scanner = Scanner.new(options: scanner_options)
+
+          if Console::Argument::Scan::Handler.fetch(key: :staged, default: false)
+            Core::Console::Logger.important(message: 'Scanning staged git changes...')
+            scanner.scan_git_diff(staged_only: true)
+          else
+            path = Console::Argument::Scan::Handler.fetch(key: :path, default: '.')
+            Core::Console::Logger.important(message: "Scanning directory: #{path}")
+            scanner.scan_directory(path:)
+          end
+        end
+
+        # Print a formatted scan report to the console
+        # @param result [ScanResult] The scan result to display
+        # @return [void]
+        def print_result(result:)
+          separator = '-' * 70
+
+          Core::Console::Logger.message(message: separator)
+          Core::Console::Logger.message(message: "\tFiles scanned:  #{result.files_count}")
+          Core::Console::Logger.message(message: "\tFindings:       #{result.findings.length}")
+          Core::Console::Logger.message(message: separator)
+
+          if result.clean?
+            Core::Console::Logger.success(message: '\t✅ No secrets found')
+          else
+            print_severity_summary(result:)
+            Core::Console::Logger.message(message: separator)
+            print_findings(result:)
+          end
+
+          Core::Console::Logger.message(message: separator)
+        end
+
+        # Print a per-severity count breakdown
+        # @param result [ScanResult] The scan result
+        # @return [void]
+        def print_severity_summary(result:)
+          counts = {
+            critical: result.by_severity(severity: :critical).length,
+            high: result.by_severity(severity: :high).length,
+            medium: result.by_severity(severity: :medium).length,
+            low: result.by_severity(severity: :low).length,
+          }
+
+          Core::Console::Logger.error(message: "\t🔴 Critical:  #{counts[:critical]}") if counts[:critical].positive?
+          Core::Console::Logger.warning(message: "\t🟠 High:      #{counts[:high]}")     if counts[:high].positive?
+          Core::Console::Logger.warning(message: "\t🟡 Medium:    #{counts[:medium]}")   if counts[:medium].positive?
+          Core::Console::Logger.message(message: "\t🔵 Low:       #{counts[:low]}")      if counts[:low].positive?
+        end
+
+        # Print each finding grouped by severity level
+        # @param result [ScanResult] The scan result
+        # @return [void]
+        def print_findings(result:)
+          %i[critical high medium low].each do |severity|
+            findings = result.by_severity(severity:)
+            next if findings.empty?
+
+            Core::Console::Logger.message(message: "\t#{severity.to_s.upcase} (#{findings.length}):")
+
+            findings.each do |finding|
+              Core::Console::Logger.message(message: "\t\t#{finding}")
+              Core::Console::Logger.message(message: "\t\t└ #{finding.full_line}")
+            end
+
+            Core::Console::Logger.message(message: '')
+          end
+        end
+
+        # Save the scan result as a pretty-printed JSON report
+        # @param result [ScanResult] The scan result to serialise
+        # @return [void]
+        def save_report(result:)
+          output = Console::Argument::Scan::Handler.fetch(key: :output)
+          File.write(output, JSON.pretty_generate(result.to_h))
+          Core::Console::Logger.success(message: "Report saved to: #{output}")
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/console/arguments/parser.rb
+++ b/lib/validation/console/arguments/parser.rb
@@ -1,0 +1,65 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require_relative '../../../core/console/logger'
+require_relative 'scan/handler'
+require_relative 'scan/parser'
+require_relative '../../actions/scan'
+
+module SecureKeys
+  module Validation
+    module Console
+      module Argument
+        # Routes the `validate` subcommand to the appropriate sub-parser and action.
+        # The constructor reads the subcommand token from ARGV; +execute+ then
+        # delegates to the matching sub-parser and runs the action.
+        class Parser < OptionParser
+          # Initialize the validate argument parser and capture the subcommand token
+          def initialize
+            super('Usage: secure-keys validate [subcommand] [--options]')
+            separator('')
+            configure!
+            @subcommand = ARGV.shift
+          end
+
+          # Dispatch to the correct sub-parser and action based on the subcommand
+          # @return [void]
+          def execute
+            case @subcommand
+            when 'scan'
+              Scan::Parser.new
+              Actions::Scan.new.run
+            when nil, '--help', '-h'
+              puts self
+              exit(0)
+            else
+              Core::Console::Logger.error(message: "Unknown validate subcommand: '#{@subcommand}'")
+              puts self
+              exit(1)
+            end
+          end
+
+          private
+
+          # Configure the validate-level help text and available subcommands
+          # @return [void]
+          def configure!
+            on('-h', '--help', 'Show help for the validate command') do
+              puts self
+              exit(0)
+            end
+            separator('')
+            separator('Subcommands:')
+            separator("\tscan [path]   Scan a directory or staged git changes for exposed secrets")
+            separator('')
+            separator('Examples:')
+            separator("\tsecure-keys validate scan")
+            separator("\tsecure-keys validate scan ./src")
+            separator("\tsecure-keys validate scan --staged")
+            separator("\tsecure-keys validate scan --output report.json")
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/console/arguments/scan/handler.rb
+++ b/lib/validation/console/arguments/scan/handler.rb
@@ -1,0 +1,31 @@
+#!/usr/bin/env ruby
+
+require_relative '../../../../core/console/arguments/fetchable'
+
+module SecureKeys
+  module Validation
+    module Console
+      module Argument
+        module Scan
+          # Stores and provides access to the resolved CLI arguments for the scan subcommand
+          class Handler
+            class << self
+              include Core::Console::Argument::Fetchable
+
+              attr_reader :arguments
+            end
+
+            # Default argument values for the scan subcommand
+            @arguments = {
+              path: '.',
+              staged: false,
+              output: nil,
+              extensions: nil,
+              excludes: nil,
+            }
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/console/arguments/scan/parser.rb
+++ b/lib/validation/console/arguments/scan/parser.rb
@@ -31,11 +31,9 @@ module SecureKeys
                 puts self
                 exit(0)
               end
-              on(
-                '--staged',
-                TrueClass,
-                'Scan staged git changes instead of a directory (default: false)'
-              )
+              on('--staged', 'Scan staged git changes instead of a directory (default: false)') do
+                Handler.set(key: :staged, value: true)
+              end
               on(
                 '-o', '--output FILE',
                 String,
@@ -51,7 +49,7 @@ module SecureKeys
                 String,
                 'Comma-separated directory names to exclude from the scan'
               )
-              on('--verbose', TrueClass, 'Enable verbose output (default: false)') do
+              on('--verbose', 'Enable verbose output (default: false)') do
                 Core::Console::Argument::Handler.set(key: :verbose, value: true)
               end
             end

--- a/lib/validation/console/arguments/scan/parser.rb
+++ b/lib/validation/console/arguments/scan/parser.rb
@@ -1,0 +1,63 @@
+#!/usr/bin/env ruby
+
+require 'optparse'
+require_relative 'handler'
+require_relative '../../../../core/console/arguments/handler'
+
+module SecureKeys
+  module Validation
+    module Console
+      module Argument
+        module Scan
+          # Parses CLI options for the `secure-keys validate scan` subcommand.
+          # Uses +parse!+ so options and positional arguments may appear in any order;
+          # after parsing, any remaining ARGV token is treated as the scan path.
+          class Parser < OptionParser
+            # Initialize the scan parser, process ARGV, and store results in Handler
+            def initialize
+              super('Usage: secure-keys validate scan [path] [--options]')
+              separator('')
+              configure!
+              parse!(into: Handler.arguments)
+              Handler.set(key: :path, value: ARGV.shift) unless ARGV.empty?
+            end
+
+            private
+
+            # Define all accepted options for the scan subcommand
+            # @return [void]
+            def configure!
+              on('-h', '--help', 'Show help for the scan subcommand') do
+                puts self
+                exit(0)
+              end
+              on(
+                '--staged',
+                TrueClass,
+                'Scan staged git changes instead of a directory (default: false)'
+              )
+              on(
+                '-o', '--output FILE',
+                String,
+                'Save the scan report as JSON to FILE'
+              )
+              on(
+                '--extensions EXTENSIONS',
+                String,
+                'Comma-separated file extensions to scan (e.g. .rb,.swift)'
+              )
+              on(
+                '--excludes EXCLUDES',
+                String,
+                'Comma-separated directory names to exclude from the scan'
+              )
+              on('--verbose', TrueClass, 'Enable verbose output (default: false)') do
+                Core::Console::Argument::Handler.set(key: :verbose, value: true)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/globals/globals.rb
+++ b/lib/validation/globals/globals.rb
@@ -1,0 +1,71 @@
+#!/usr/bin/env ruby
+
+require_relative '../../services/environment'
+
+module SecureKeys
+  module Validation
+    module Globals
+      module_function
+
+      # Returns the minimum length for an API key
+      # @return [Integer] The minimum length for an API key
+      def api_key_length
+        Services::Environment.integer(key: :api_key_length, default: 20)
+      end
+
+      # Returns the minimum length for a token
+      # @return [Integer] The minimum length for a token
+      def token_length
+        Services::Environment.integer(key: :token_length, default: 20)
+      end
+
+      # Returns the minimum length for a secret
+      # @return [Integer] The minimum length for a secret
+      def secret_length
+        Services::Environment.integer(key: :secret_length, default: 16)
+      end
+
+      # Returns the minimum length for a password
+      # @return [Integer] The minimum length for a password
+      def password_length
+        Services::Environment.integer(key: :password_length, default: 12)
+      end
+
+      # Returns the minimum length for a generic key
+      # @return [Integer] The minimum length for a key
+      def key_length
+        Services::Environment.integer(key: :key_length, default: 16)
+      end
+
+      # Returns the default file extensions to scan
+      # @return [Array<String>] The default file extensions
+      def default_scan_extensions
+        Services::Environment.fetch(
+          key: :scan_extensions,
+          default: '.swift,.m,.mm,.h,.rb,.py,.js,.ts,.java,.kt,.yaml,.yml,.json,.env,.plist'
+        ).split(',')
+      end
+
+      # Returns the default directory and file names to exclude from scanning
+      # @return [Array<String>] The default exclude patterns
+      def default_scan_excludes
+        Services::Environment.fetch(
+          key: :scan_excludes,
+          default: '.git,node_modules,Pods,build,DerivedData,.build,vendor,.bundle,Carthage,.secure-keys,coverage'
+        ).split(',')
+      end
+
+      # Returns the maximum directory traversal depth for scanning
+      # @return [Integer] The maximum scan depth
+      def max_scan_depth
+        Services::Environment.integer(key: :max_scan_depth, default: 10)
+      end
+
+      # Returns the minimum Shannon entropy threshold for secret validation
+      # @return [Float] The minimum entropy threshold
+      def min_entropy_threshold
+        Services::Environment.decimal(key: :min_entropy_threshold, default: 3.0)
+      end
+    end
+  end
+end

--- a/lib/validation/models/finding.rb
+++ b/lib/validation/models/finding.rb
@@ -1,0 +1,76 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Validation
+    # Represents a single secret detected during a file or git diff scan
+    class Finding
+      attr_reader :file, :line, :column, :type, :description, :severity,
+                  :matched_text, :full_line, :is_addition
+
+      # Initialize a new finding
+      # @param file [String] The file path where the secret was found
+      # @param line [Integer] The line number where the secret was found
+      # @param column [Integer] The column offset of the match within the line
+      # @param type [Symbol] The pattern type that matched (e.g. :github_token, :aws_access_key)
+      # @param description [String] A human-readable description of the secret type
+      # @param severity [Symbol] The severity level (:low, :medium, :high, :critical)
+      # @param matched_text [String] The masked matched text, safe for display
+      # @param full_line [String] The full trimmed line of code containing the secret
+      # @param is_addition [Boolean] Whether this line is an addition in a git diff (default: false)
+      def initialize(file:, line:, column:, type:, description:, severity:,
+                     matched_text:, full_line:, is_addition: false)
+        @file = file
+        @line = line
+        @column = column
+        @type = type
+        @description = description
+        @severity = severity
+        @matched_text = matched_text
+        @full_line = full_line
+        @is_addition = is_addition
+      end
+
+      # Check if this finding came from a git diff addition
+      # @return [Boolean] true if the line is a git diff addition
+      def addition?
+        is_addition
+      end
+
+      # Returns a one-line string representation of the finding
+      # @return [String] The formatted finding string
+      def to_s
+        "#{severity_icon} #{file}:#{line}:#{column} [#{type}] #{description} — #{matched_text}"
+      end
+
+      # Returns a hash representation of the finding
+      # @return [Hash] The hash representation
+      def to_h
+        {
+          file:,
+          line:,
+          column:,
+          type:,
+          description:,
+          severity:,
+          matched_text:,
+          full_line:,
+          is_addition:,
+        }
+      end
+
+      private
+
+      # Returns the appropriate icon for the severity level
+      # @return [String] The severity icon
+      def severity_icon
+        case severity
+        when :critical then '🔴'
+        when :high then '🟠'
+        when :medium then '🟡'
+        when :low then '🔵'
+        else '⚪'
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/models/scan_result.rb
+++ b/lib/validation/models/scan_result.rb
@@ -1,0 +1,47 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Validation
+    # Aggregates all findings from a single scan run
+    class ScanResult
+      attr_reader :findings, :files_count
+
+      # Initialize a new scan result
+      # @param findings [Array<Finding>] The list of detected secrets
+      # @param files_count [Integer] The total number of files (or diff lines) scanned
+      def initialize(findings:, files_count:)
+        @findings = findings
+        @files_count = files_count
+      end
+
+      # Check if the scan produced no findings
+      # @return [Boolean] true if no secrets were detected
+      def clean?
+        findings.empty?
+      end
+
+      # Returns findings filtered by a specific severity level
+      # @param severity [Symbol] The severity to filter by (:low, :medium, :high, :critical)
+      # @return [Array<Finding>] Findings matching the given severity
+      def by_severity(severity:)
+        findings.select { |finding| finding.severity == severity }
+      end
+
+      # Returns a hash representation of the scan result
+      # @return [Hash] The hash representation, suitable for JSON export
+      def to_h
+        {
+          files_scanned: files_count,
+          total_findings: findings.length,
+          by_severity: {
+            critical: by_severity(severity: :critical).length,
+            high: by_severity(severity: :high).length,
+            medium: by_severity(severity: :medium).length,
+            low: by_severity(severity: :low).length,
+          },
+          findings: findings.map(&:to_h),
+        }
+      end
+    end
+  end
+end

--- a/lib/validation/scanner.rb
+++ b/lib/validation/scanner.rb
@@ -1,0 +1,256 @@
+#!/usr/bin/env ruby
+
+require_relative '../core/console/logger'
+require_relative '../core/console/shell'
+require_relative 'globals/globals'
+require_relative 'utils/patterns'
+require_relative 'models/finding'
+require_relative 'models/scan_result'
+
+module SecureKeys
+  module Validation
+    # Scans files and git diffs for exposed secrets using the known PATTERNS set
+    class Scanner
+      private
+
+      attr_accessor :findings, :options
+
+      public
+
+      # Initialize a new scanner
+      # @param options [Hash] Override specific default scanning options
+      # @option options [Array<String>] :extensions File extensions to include in the scan
+      # @option options [Array<String>] :excludes Directory and file names to exclude
+      # @option options [Integer] :max_depth Maximum directory traversal depth
+      # @option options [Boolean] :follow_symlinks Whether to follow symbolic links
+      def initialize(options: {})
+        self.options = default_options.merge(options)
+        self.findings = []
+      end
+
+      # Scan a directory recursively for exposed secrets
+      # @param path [String] The root directory path to scan (default: current directory)
+      # @param options [Hash] Additional options to merge for this scan only
+      # @return [ScanResult] The aggregated scan result
+      def scan_directory(path: '.', options: {})
+        self.findings = []
+        self.options = self.options.merge(options)
+
+        Core::Console::Logger.verbose(message: "Scanning directory: #{path}")
+        Core::Console::Logger.verbose(message: "Extensions: #{file_extensions.join(', ')}")
+        Core::Console::Logger.verbose(message: "Excludes: #{exclude_patterns.join(', ')}")
+
+        files = find_files(path:)
+
+        Core::Console::Logger.verbose(message: "Found #{files.length} files to scan")
+
+        files.each { |file| scan_file(file_path: file) }
+
+        ScanResult.new(findings:, files_count: files.length)
+      end
+
+      # Scan staged or unstaged git changes for exposed secrets
+      # @param staged_only [Boolean] When true, scans only staged changes (default: true)
+      # @return [ScanResult] The aggregated scan result
+      def scan_git_diff(staged_only: true)
+        self.findings = []
+
+        command = staged_only ? 'git diff --cached' : 'git diff'
+        diff_output, = Core::Console::Shell.sh(command:)
+
+        return ScanResult.new(findings: [], files_count: 0) if diff_output.strip.empty?
+
+        current_file = nil
+        line_number = 0
+
+        diff_output.each_line do |line|
+          if line.start_with?('+++')
+            current_file = line.sub(%r{^\+\+\+ b/}, '').strip
+            line_number = 0
+          elsif line.start_with?('+') && current_file && !line.start_with?('+++')
+            line_number += 1
+            check_line(
+              file_path: current_file,
+              line_number:,
+              line: line[1..],
+              is_addition: true
+            )
+          end
+        end
+
+        ScanResult.new(findings:, files_count: diff_output.lines.count)
+      end
+
+      private
+
+      # Scan a single file line by line for exposed secrets
+      # @param file_path [String] The path to the file to scan
+      def scan_file(file_path:)
+        return unless File.file?(file_path)
+
+        Core::Console::Logger.verbose(message: "Scanning #{file_path}...")
+
+        content = File.read(file_path)
+        line_number = 0
+
+        content.each_line do |line|
+          line_number += 1
+          check_line(file_path:, line_number:, line:)
+        end
+      rescue StandardError => e
+        Core::Console::Logger.verbose(message: "Failed to scan #{file_path}: #{e.message}")
+      end
+
+      # Check a single line against all known secret patterns and suspicious assignments
+      # @param file_path [String] The path of the file being scanned
+      # @param line_number [Integer] The current line number within the file
+      # @param line [String] The content of the line to check
+      # @param is_addition [Boolean] Whether the line is a git diff addition (default: false)
+      def check_line(file_path:, line_number:, line:, is_addition: false)
+        return if line.strip.start_with?('#', '//', '/*', '*')
+        return if line.length < 10
+
+        PATTERNS.each do |type, config|
+          next unless line.match?(config[:pattern])
+
+          match = line.match(config[:pattern])
+
+          findings << Finding.new(
+            file: file_path,
+            line: line_number,
+            column: match.begin(0),
+            type:,
+            description: config[:description],
+            severity: config[:severity],
+            matched_text: mask_secret(secret: match[0]),
+            full_line: line.strip,
+            is_addition:
+          )
+        end
+
+        check_suspicious_assignments(file_path:, line_number:, line:, is_addition:)
+      end
+
+      # Check a line for generic suspicious variable assignment patterns not caught by PATTERNS
+      # @param file_path [String] The path of the file being scanned
+      # @param line_number [Integer] The current line number within the file
+      # @param line [String] The content of the line
+      # @param is_addition [Boolean] Whether the line is a git diff addition
+      def check_suspicious_assignments(file_path:, line_number:, line:, is_addition:)
+        suspicious_pattern = /(?i)(api_?key|secret|token|password|passwd|pwd|auth|credential)\s*[=:]\s*['"]([^'"]{8,})['"]/
+
+        return unless line.match?(suspicious_pattern)
+        return if already_matched_by_pattern?(line:)
+
+        match = line.match(suspicious_pattern)
+
+        findings << Finding.new(
+          file: file_path,
+          line: line_number,
+          column: match.begin(0),
+          type: :suspicious_assignment,
+          description: 'Suspicious secret assignment',
+          severity: :low,
+          matched_text: mask_secret(secret: match[0]),
+          full_line: line.strip,
+          is_addition:
+        )
+      end
+
+      # Check whether a line was already captured by one of the specific PATTERNS
+      # @param line [String] The line content to check
+      # @return [Boolean] true if the line matches any known pattern
+      def already_matched_by_pattern?(line:)
+        PATTERNS.values.any? { |config| line.match?(config[:pattern]) }
+      end
+
+      # Recursively find all scannable files under a root path
+      # @param path [String] The root directory path
+      # @return [Array<String>] The list of matching absolute file paths
+      def find_files(path:)
+        result = []
+        traverse_directory(
+          path:,
+          result:,
+          current_depth: 0,
+          max_depth: options.fetch(:max_depth, Globals.max_scan_depth)
+        )
+        result
+      end
+
+      # Recursively traverse a directory, collecting files that match the scan criteria
+      # @param path [String] The current directory path
+      # @param result [Array<String>] The accumulator for matching file paths
+      # @param current_depth [Integer] The current traversal depth
+      # @param max_depth [Integer] The maximum allowed traversal depth
+      def traverse_directory(path:, result:, current_depth:, max_depth:)
+        return if current_depth > max_depth
+
+        Dir.each_child(path) do |entry|
+          next if excluded?(name: entry)
+
+          full_path = File.join(path, entry)
+
+          if File.directory?(full_path)
+            traverse_directory(
+              path: full_path,
+              result:,
+              current_depth: current_depth + 1,
+              max_depth:
+            )
+          elsif File.file?(full_path) && included_extension?(path: full_path)
+            result << full_path
+          end
+        end
+      rescue Errno::EACCES, Errno::ENOENT => e
+        Core::Console::Logger.verbose(message: "Skipping #{path}: #{e.message}")
+      end
+
+      # Check whether a file or directory name matches an exclude pattern
+      # @param name [String] The file or directory name to check
+      # @return [Boolean] true if the entry should be excluded
+      def excluded?(name:)
+        exclude_patterns.any? { |pattern| name == pattern }
+      end
+
+      # Check whether a file path has an extension that should be scanned
+      # @param path [String] The file path to check
+      # @return [Boolean] true if the file extension is in the inclusion list
+      def included_extension?(path:)
+        file_extensions.include?(File.extname(path))
+      end
+
+      # Returns the configured list of file extensions to scan
+      # @return [Array<String>] The file extensions
+      def file_extensions
+        options.fetch(:extensions, Globals.default_scan_extensions)
+      end
+
+      # Returns the configured list of directory and file names to exclude
+      # @return [Array<String>] The exclude patterns
+      def exclude_patterns
+        options.fetch(:excludes, Globals.default_scan_excludes)
+      end
+
+      # Mask a secret value so only the first four characters are visible
+      # @param secret [String] The secret string to mask
+      # @return [String] The masked string, safe for display in logs
+      def mask_secret(secret:)
+        return '***' if secret.length <= 6
+
+        "#{secret[0..3]}#{'*' * (secret.length - 4)}"
+      end
+
+      # Builds the default scanning options from globals
+      # @return [Hash] The default options hash
+      def default_options
+        {
+          extensions: Globals.default_scan_extensions,
+          excludes: Globals.default_scan_excludes,
+          max_depth: Globals.max_scan_depth,
+          follow_symlinks: false,
+        }
+      end
+    end
+  end
+end

--- a/lib/validation/scanner.rb
+++ b/lib/validation/scanner.rb
@@ -67,6 +67,9 @@ module SecureKeys
           if line.start_with?('+++')
             current_file = line.sub(%r{^\+\+\+ b/}, '').strip
             line_number = 0
+          elsif line.start_with?('@@') && current_file
+            hunk_match = line.match(/\+(\d+)/)
+            line_number = hunk_match ? hunk_match[1].to_i - 1 : 0
           elsif line.start_with?('+') && current_file && !line.start_with?('+++')
             line_number += 1
             check_line(
@@ -110,10 +113,17 @@ module SecureKeys
         return if line.strip.start_with?('#', '//', '/*', '*')
         return if line.length < 10
 
-        PATTERNS.each do |type, config|
-          next unless line.match?(config[:pattern])
+        seen = {}
 
+        PATTERNS.each do |type, config|
           match = line.match(config[:pattern])
+          next unless match
+
+          signature = [match.begin(0), match[0]]
+          next if seen[signature]
+
+          seen[signature] = true
+          masked = mask_secret(secret: match[0])
 
           findings << Finding.new(
             file: file_path,
@@ -122,8 +132,8 @@ module SecureKeys
             type:,
             description: config[:description],
             severity: config[:severity],
-            matched_text: mask_secret(secret: match[0]),
-            full_line: line.strip,
+            matched_text: masked,
+            full_line: line.strip.sub(match[0], masked),
             is_addition:
           )
         end
@@ -143,6 +153,7 @@ module SecureKeys
         return if already_matched_by_pattern?(line:)
 
         match = line.match(suspicious_pattern)
+        masked = mask_secret(secret: match[0])
 
         findings << Finding.new(
           file: file_path,
@@ -151,8 +162,8 @@ module SecureKeys
           type: :suspicious_assignment,
           description: 'Suspicious secret assignment',
           severity: :low,
-          matched_text: mask_secret(secret: match[0]),
-          full_line: line.strip,
+          matched_text: masked,
+          full_line: line.strip.sub(match[0], masked),
           is_addition:
         )
       end
@@ -190,6 +201,8 @@ module SecureKeys
           next if excluded?(name: entry)
 
           full_path = File.join(path, entry)
+
+          next if File.symlink?(full_path) && !options.fetch(:follow_symlinks, false)
 
           if File.directory?(full_path)
             traverse_directory(

--- a/lib/validation/utils/entropy.rb
+++ b/lib/validation/utils/entropy.rb
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Validation
+    module Entropy
+      module_function
+
+      # Calculate the Shannon entropy of a string
+      # @param string [String] The string to analyze
+      # @return [Float] The Shannon entropy value (higher means more random)
+      def calculate(string:)
+        return 0.0 if string.empty?
+
+        frequencies = Hash.new(0)
+        string.each_char { |char| frequencies[char] += 1 }
+
+        frequencies.each_value.sum do |count|
+          frequency = count.to_f / string.length
+          -frequency * Math.log2(frequency)
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/utils/min_length.rb
+++ b/lib/validation/utils/min_length.rb
@@ -1,0 +1,16 @@
+#!/usr/bin/env ruby
+
+require_relative '../globals/globals'
+
+module SecureKeys
+  module Validation
+    # Minimum length requirements by key type
+    MIN_LENGTHS = {
+      api_key: Globals.api_key_length,
+      token: Globals.token_length,
+      secret: Globals.secret_length,
+      password: Globals.password_length,
+      key: Globals.key_length,
+    }.freeze
+  end
+end

--- a/lib/validation/utils/patterns.rb
+++ b/lib/validation/utils/patterns.rb
@@ -1,0 +1,204 @@
+#!/usr/bin/env ruby
+
+# rubocop:disable Lint/Syntax, Metrics/ModuleLength
+
+module SecureKeys
+  module Validation
+    # Known secret patterns with descriptions
+    PATTERNS = {
+      # GitHub
+      github_token: {
+        pattern: /ghp_[a-zA-Z0-9]{36}/,
+        description: 'GitHub Personal Access Token',
+        severity: :high,
+        example: 'ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+      github_oauth: {
+        pattern: /gho_[a-zA-Z0-9]{36}/,
+        description: 'GitHub OAuth Access Token',
+        severity: :high,
+        example: 'gho_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+      github_app: {
+        pattern: /(ghu|ghs)_[a-zA-Z0-9]{36}/,
+        description: 'GitHub App Token',
+        severity: :high,
+        example: 'ghu_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+      github_refresh: {
+        pattern: /ghr_[a-zA-Z0-9]{36}/,
+        description: 'GitHub Refresh Token',
+        severity: :high,
+        example: 'ghr_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+
+      # AWS
+      aws_access_key: {
+        pattern: /AKIA[0-9A-Z]{16}/,
+        description: 'AWS Access Key ID',
+        severity: :critical,
+        example: 'AKIAIOSFODNN7EXAMPLE'
+      },
+      aws_secret_key: {
+        pattern: %r{(?i)aws(.{0,20})?['\"][0-9a-zA-Z/+]{40}['\"]},
+        description: 'AWS Secret Access Key',
+        severity: :critical,
+        example: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
+      },
+      aws_session_token: {
+        pattern: %r{(?i)aws(.{0,20})?session(.{0,20})?['\"][0-9a-zA-Z/+]{100,}['\"]},
+        description: 'AWS Session Token',
+        severity: :high,
+        example: 'FwoGZXIvYXdzEBaa...(very long token)'
+      },
+
+      # Google Cloud
+      gcp_api_key: {
+        pattern: /AIza[0-9A-Za-z\-_]{35}/,
+        description: 'Google Cloud API Key',
+        severity: :high,
+        example: 'AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe'
+      },
+      gcp_oauth: {
+        pattern: /ya29\.[0-9A-Za-z\-_]+/,
+        description: 'Google OAuth Access Token',
+        severity: :high,
+        example: 'ya29.a0AfH6SMBx...'
+      },
+
+      # Stripe
+      stripe_secret_key: {
+        pattern: /sk_(live|test)_[0-9a-zA-Z]{24,}/,
+        description: 'Stripe Secret Key',
+        severity: :critical,
+        example: 'sk_live_51H...'
+      },
+      stripe_publishable_key: {
+        pattern: /pk_(live|test)_[0-9a-zA-Z]{24,}/,
+        description: 'Stripe Publishable Key',
+        severity: :medium,
+        example: 'pk_live_51H...'
+      },
+      stripe_restricted_key: {
+        pattern: /rk_(live|test)_[0-9a-zA-Z]{24,}/,
+        description: 'Stripe Restricted Key',
+        severity: :high,
+        example: 'rk_live_51H...'
+      },
+
+      # Slack
+      slack_token: {
+        pattern: /xox[baprs]-[0-9a-zA-Z]{10,48}/,
+        description: 'Slack Token',
+        severity: :high,
+        example: 'xoxb-1234567890123-1234567890123-xxxxxxxxxxxxx'
+      },
+      slack_webhook: {
+        pattern: %r{https://hooks\.slack\.com/services/T[a-zA-Z0-9_]{8,}/B[a-zA-Z0-9_]{8,}/[a-zA-Z0-9_]{24}},
+        description: 'Slack Webhook URL',
+        severity: :medium,
+        example: 'https://hooks.slack.com/services/T00000000/B00000000/XXXXXXXXXXXXXXXXXXXXXXXX'
+      },
+
+      # OAuth & JWT
+      jwt_token: {
+        pattern: %r{eyJ[A-Za-z0-9\-_=]+\.eyJ[A-Za-z0-9\-_=]+\.?[A-Za-z0-9\-_.+/=]*},
+        description: 'JWT Token',
+        severity: :medium,
+        example: 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dozjgNryP4J3jVmNHl0w5N_XgL0n3I9PlFUP0THsR8U'
+      },
+
+      # Generic patterns
+      private_key: {
+        pattern: /-----BEGIN (RSA |EC |OPENSSH |DSA )?PRIVATE KEY-----/,
+        description: 'Private Key',
+        severity: :critical,
+        example: '-----BEGIN PRIVATE KEY-----'
+      },
+      generic_api_key: {
+        pattern: /(?i)(api[_-]?key|apikey)[\s]*[:=][\s]*['\"]([a-zA-Z0-9_\-]{20,})['\"]/,
+        description: 'Generic API Key',
+        severity: :medium,
+        example: 'api_key: "abcdef1234567890abcdef1234567890"'
+      },
+      generic_secret: {
+        pattern: /(?i)(secret|password|passwd|pwd)[\s]*[:=][\s]*['\"]([^\s'\"]{8,})['\"]/,
+        description: 'Generic Secret/Password',
+        severity: :medium,
+        example: 'secret: "mysecretpassword123"'
+      },
+
+      # Firebase
+      firebase_key: {
+        pattern: /AIza[0-9A-Za-z\-_]{35}/,
+        description: 'Firebase API Key',
+        severity: :medium,
+        example: 'AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe'
+      },
+
+      # Twilio
+      twilio_api_key: {
+        pattern: /SK[a-z0-9]{32}/,
+        description: 'Twilio API Key',
+        severity: :high,
+        example: 'SKxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+      twilio_account_sid: {
+        pattern: /AC[a-z0-9]{32}/,
+        description: 'Twilio Account SID',
+        severity: :low,
+        example: 'ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+
+      # SendGrid
+      sendgrid_api_key: {
+        pattern: /SG\.[a-zA-Z0-9_\-]{22}\.[a-zA-Z0-9_\-]{43}/,
+        description: 'SendGrid API Key',
+        severity: :high,
+        example: 'SG.xxxxxxxxxxxxxxxxxxxxxx.xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+
+      # Mailchimp
+      mailchimp_api_key: {
+        pattern: /[a-f0-9]{32}-us[0-9]{1,2}/,
+        description: 'Mailchimp API Key',
+        severity: :medium,
+        example: 'abcdef1234567890abcdef1234567890-us19'
+      },
+
+      # Square
+      square_access_token: {
+        pattern: /sq0atp-[0-9A-Za-z\-_]{22}/,
+        description: 'Square Access Token',
+        severity: :high,
+        example: 'sq0atp-xxxxxxxxxxxxxxxxxxxxxx'
+      },
+
+      # PayPal
+      paypal_braintree: {
+        pattern: /access_token\$production\$[a-z0-9]{16}\$[a-f0-9]{32}/,
+        description: 'PayPal Braintree Access Token',
+        severity: :critical,
+        example: 'access_token$production$xxxxxxxxxxxxxxxx$xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+      },
+
+      # Heroku
+      heroku_api_key: {
+        pattern: /[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/,
+        description: 'Heroku API Key (UUID format)',
+        severity: :high,
+        example: '12345678-1234-1234-1234-123456789012'
+      },
+
+      # Generic Base64 secrets (often used for keys)
+      base64_secret: {
+        pattern: %r{(?i)(secret|key|token|password)[\s]*[:=][\s]*['\"]([A-Za-z0-9+/]{40,}={0,2})['\"]},
+        description: 'Base64 Encoded Secret',
+        severity: :low,
+        example: 'secret: "YWJjZGVmZ2hpamtsbW5vcHFyc3R1dnd4eXoxMjM0NTY3ODkw"'
+      }
+    }.freeze
+  end
+end
+
+# rubocop:enable Lint/Syntax, Metrics/ModuleLength

--- a/lib/validation/utils/weak_secrets.rb
+++ b/lib/validation/utils/weak_secrets.rb
@@ -1,0 +1,13 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Validation
+    # Common weak or test values that should never be used
+    WEAK_SECRETS = %w[
+      password password123 123456 secret test demo
+      admin root changeme temp default example
+      sample placeholder your-key-here YOUR_API_KEY
+      xxxxxxxxxxxx 0000000000 1234567890
+    ].freeze
+  end
+end

--- a/lib/validation/utils/weak_secrets.rb
+++ b/lib/validation/utils/weak_secrets.rb
@@ -6,7 +6,7 @@ module SecureKeys
     WEAK_SECRETS = %w[
       password password123 123456 secret test demo
       admin root changeme temp default example
-      sample placeholder your-key-here YOUR_API_KEY
+      sample placeholder your-key-here your_api_key
       xxxxxxxxxxxx 0000000000 1234567890
     ].freeze
   end

--- a/lib/validation/validation_issue.rb
+++ b/lib/validation/validation_issue.rb
@@ -1,0 +1,55 @@
+#!/usr/bin/env ruby
+
+module SecureKeys
+  module Validation
+    # Represents a single issue detected during secret validation
+    class ValidationIssue
+      attr_reader :severity, :type, :message, :recommendation
+
+      # Initialize a new validation issue
+      # @param severity [Symbol] The severity level (:critical, :error, :warning, :info)
+      # @param type [Symbol] The category of the issue (e.g. :empty_value, :weak_secret)
+      # @param message [String] A human-readable description of the issue
+      # @param recommendation [String, nil] An optional actionable recommendation for the developer
+      def initialize(severity:, type:, message:, recommendation:)
+        @severity = severity
+        @type = type
+        @message = message
+        @recommendation = recommendation
+      end
+
+      # Returns a string representation of the issue, including the recommendation if present
+      # @return [String] The formatted issue string
+      def to_s
+        text = "#{severity_icon} #{severity.upcase}: #{message}"
+        text += "\n\t\t💡 #{recommendation}" if recommendation
+        text
+      end
+
+      # Returns a hash representation of the issue
+      # @return [Hash] The hash representation
+      def to_h
+        {
+          severity:,
+          type:,
+          message:,
+          recommendation:,
+        }
+      end
+
+      private
+
+      # Returns the appropriate icon for the severity level
+      # @return [String] The severity icon
+      def severity_icon
+        case severity
+        when :critical then '🔴'
+        when :error then '❌'
+        when :warning then '⚠️'
+        when :info then 'ℹ️'
+        else '•'
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/validation_result.rb
+++ b/lib/validation/validation_result.rb
@@ -1,0 +1,117 @@
+#!/usr/bin/env ruby
+
+require_relative '../core/console/logger'
+
+module SecureKeys
+  module Validation
+    # Encapsulates the result of validating a single secret value
+    class ValidationResult
+      private
+
+      attr_writer :key, :value, :issues, :detected_type
+
+      public
+
+      attr_reader :key, :value, :issues, :detected_type
+
+      # Initialize a new validation result
+      # @param key [Symbol] The key identifier that was validated
+      # @param value [String] The value that was validated
+      # @param issues [Array<ValidationIssue>] The list of issues found during validation
+      # @param detected_type [Hash, nil] The detected secret type config, if any pattern matched
+      def initialize(key:, value:, issues:, detected_type: nil)
+        @key = key
+        @value = value
+        @issues = issues
+        @detected_type = detected_type
+      end
+
+      # Check if validation passed with no errors or critical issues
+      # @return [Boolean] true if no critical or error issues were found
+      def valid?
+        !errors? && !critical?
+      end
+
+      # Check if any critical-severity issues were found
+      # @return [Boolean] true if critical issues exist
+      def critical?
+        issues.any? { |issue| issue.severity == :critical }
+      end
+
+      # Check if any error-severity issues were found
+      # @return [Boolean] true if error issues exist
+      def errors?
+        issues.any? { |issue| issue.severity == :error }
+      end
+
+      # Check if any warning-severity issues were found
+      # @return [Boolean] true if warning issues exist
+      def warnings?
+        issues.any? { |issue| issue.severity == :warning }
+      end
+
+      # Returns the highest severity level across all issues
+      # @return [Symbol] :critical, :error, :warning, or :ok
+      def severity_level
+        return :critical if critical?
+        return :error if errors?
+        return :warning if warnings?
+
+        :ok
+      end
+
+      # Returns a one-line summary of the validation outcome
+      # @return [String] The summary string
+      def summary
+        return "✅ '#{key}' passed validation" if valid?
+
+        "#{severity_icon} '#{key}' has #{issues.length} issue(s)"
+      end
+
+      # Prints the full validation result to the console via Logger
+      def print
+        Core::Console::Logger.message(message: "\nValidation Result for '#{key}':")
+        Core::Console::Logger.message(message: '-' * 70)
+
+        if detected_type
+          Core::Console::Logger.message(message: "Detected Type: #{detected_type[:description]}")
+          Core::Console::Logger.message(message: "Severity:      #{detected_type[:severity]}")
+        end
+
+        if issues.empty?
+          Core::Console::Logger.success(message: '✅ No issues found')
+        else
+          Core::Console::Logger.message(message: '')
+          issues.each { |issue| Core::Console::Logger.message(message: "  #{issue}") }
+        end
+
+        Core::Console::Logger.message(message: '-' * 70)
+      end
+
+      # Returns a hash representation of the validation result
+      # @return [Hash] The hash representation
+      def to_h
+        {
+          key:,
+          valid: valid?,
+          severity: severity_level,
+          detected_type:,
+          issues: issues.map(&:to_h),
+        }
+      end
+
+      private
+
+      # Returns the appropriate icon for the current severity level
+      # @return [String] The severity icon
+      def severity_icon
+        case severity_level
+        when :critical then '🔴'
+        when :error then '❌'
+        when :warning then '⚠️'
+        else '✅'
+        end
+      end
+    end
+  end
+end

--- a/lib/validation/validator.rb
+++ b/lib/validation/validator.rb
@@ -1,0 +1,203 @@
+#!/usr/bin/env ruby
+
+require_relative 'globals/globals'
+require_relative 'utils/weak_secrets'
+require_relative 'utils/patterns'
+require_relative 'utils/min_length'
+require_relative 'utils/entropy'
+require_relative 'validation_issue'
+require_relative 'validation_result'
+
+module SecureKeys
+  module Validation
+    # Validates individual secret values against known patterns and security rules
+    class Validator
+      private
+
+      attr_accessor :issues
+
+      public
+
+      # Initialize a new validator
+      def initialize
+        self.issues = []
+      end
+
+      # Validate a single secret value against all configured rules
+      # @param key [Symbol] The key identifier for the secret
+      # @param value [String] The value to validate
+      # @param options [Hash] Additional validation options
+      # @option options [Boolean] :check_entropy Enable Shannon entropy checking (default: false)
+      # @option options [Boolean] :allow_production Skip production key warnings (default: false)
+      # @option options [Boolean] :warn_on_pattern Emit informational notices for matched patterns (default: false)
+      # @return [ValidationResult] The result of the validation
+      def validate(key:, value:, options: {})
+        self.issues = []
+
+        check_empty(key:, value:)
+        check_weak_secret(key:, value:)
+        check_minimum_length(key:, value:)
+        check_pattern_match(key:, value:, options:)
+        check_entropy(key:, value:) if options[:check_entropy]
+
+        ValidationResult.new(key:, value:, issues:, detected_type: detect_type(value:))
+      end
+
+      # Detect the secret type of a value by matching against known patterns
+      # @param value [String] The value to analyze
+      # @return [Hash, nil] The matching pattern config merged with :type key, or nil if no match
+      def detect_type(value:)
+        PATTERNS.each do |type, config|
+          return config.merge(type:) if value.to_s.match?(config[:pattern])
+        end
+
+        nil
+      end
+
+      # Returns security recommendations for a given key name
+      # @param key [Symbol] The key identifier
+      # @return [Array<String>] List of actionable recommendations
+      def recommendations(key:)
+        result = []
+        formatted_key = key.to_s.downcase
+
+        if formatted_key.include?('github')
+          result << 'Use GitHub Personal Access Tokens with minimal required scopes'
+          result << 'Consider fine-grained tokens with repository-specific access'
+        end
+
+        if formatted_key.include?('aws')
+          result << 'Use AWS IAM roles instead of long-lived access keys when possible'
+          result << 'Enable MFA for all IAM users with access keys'
+          result << 'Rotate AWS access keys every 90 days'
+        end
+
+        if formatted_key.include?('stripe')
+          result << 'Never commit live Stripe keys to version control'
+          result << 'Use Stripe test keys for development and staging'
+          result << 'Consider Stripe restricted keys with minimal permissions'
+        end
+
+        if formatted_key.include?('api') || formatted_key.include?('key')
+          result << 'Rotate this key regularly (every 90 days recommended)'
+          result << 'Use environment-specific keys for dev, staging, and production'
+        end
+
+        result
+      end
+
+      private
+
+      # Check if the value is empty
+      # @param key [Symbol] The key identifier
+      # @param value [String] The value to check
+      def check_empty(key:, value:)
+        return unless value.to_s.empty?
+
+        issues << ValidationIssue.new(
+          severity: :error,
+          type: :empty_value,
+          message: "Key '#{key}' has an empty value",
+          recommendation: 'Provide a non-empty secret value'
+        )
+      end
+
+      # Check if the value is a known weak or placeholder secret
+      # @param key [Symbol] The key identifier
+      # @param value [String] The value to check
+      def check_weak_secret(key:, value:)
+        return unless value
+
+        formatted_value = value.downcase
+
+        WEAK_SECRETS.each do |weak|
+          next unless formatted_value == weak || formatted_value.include?(weak)
+
+          issues << ValidationIssue.new(
+            severity: :critical,
+            type: :weak_secret,
+            message: "Key '#{key}' uses a weak or placeholder value matching '#{weak}'",
+            recommendation: 'Replace with a strong, randomly generated secret'
+          )
+        end
+      end
+
+      # Check if the value meets the minimum length requirement for its inferred key type
+      # @param key [Symbol] The key identifier
+      # @param value [String] The value to check
+      def check_minimum_length(key:, value:)
+        return unless value
+
+        key_type = determine_key_type(key:)
+        min_length = MIN_LENGTHS[key_type] || MIN_LENGTHS[:key]
+
+        return unless value.length < min_length
+
+        issues << ValidationIssue.new(
+          severity: :warning,
+          type: :too_short,
+          message: "Key '#{key}' is too short (#{value.length} chars, minimum is #{min_length})",
+          recommendation: "Use a longer secret (recommended: #{min_length * 2}+ characters)"
+        )
+      end
+
+      # Check if the value matches a known production secret pattern
+      # @param key [Symbol] The key identifier
+      # @param value [String] The value to check
+      # @param options [Hash] Validation options controlling severity behaviour
+      def check_pattern_match(key:, value:, options:)
+        return unless value
+
+        detected = detect_type(value:)
+        return unless detected
+
+        if detected[:severity] == :critical && !options[:allow_production]
+          issues << ValidationIssue.new(
+            severity: :critical,
+            type: :production_key_detected,
+            message: "Key '#{key}' appears to be a live #{detected[:description]}",
+            recommendation: 'Use test or development keys locally. Store production keys in your CI/CD secrets manager.'
+          )
+        elsif options[:warn_on_pattern]
+          issues << ValidationIssue.new(
+            severity: :info,
+            type: :pattern_detected,
+            message: "Key '#{key}' matches the pattern for: #{detected[:description]}",
+            recommendation: nil
+          )
+        end
+      end
+
+      # Check if the value has sufficient Shannon entropy to be a strong secret
+      # @param key [Symbol] The key identifier
+      # @param value [String] The value to check
+      def check_entropy(key:, value:)
+        return unless value
+
+        entropy = Entropy.calculate(string: value)
+        return unless entropy < Globals.min_entropy_threshold
+
+        issues << ValidationIssue.new(
+          severity: :warning,
+          type: :low_entropy,
+          message: "Key '#{key}' has low entropy (#{entropy.round(2)})",
+          recommendation: 'Use a more random secret with a wider variety of characters'
+        )
+      end
+
+      # Infer the semantic key type from the key name for minimum-length lookup
+      # @param key [Symbol] The key identifier
+      # @return [Symbol] One of :api_key, :token, :secret, :password, or :key
+      def determine_key_type(key:)
+        formatted_key = key.to_s.downcase
+
+        return :api_key if formatted_key.include?('api') && formatted_key.include?('key')
+        return :token if formatted_key.include?('token')
+        return :secret if formatted_key.include?('secret')
+        return :password if formatted_key.include?('password') || formatted_key.include?('pwd')
+
+        :key
+      end
+    end
+  end
+end

--- a/spec/core/environment/ci_spec.rb
+++ b/spec/core/environment/ci_spec.rb
@@ -1,0 +1,41 @@
+require 'core/environment/ci'
+require 'core/globals/globals'
+
+describe(SecureKeys::Core::Environment::CI) do
+  let(:environment) { described_class.new }
+
+  after(:each) do
+    %w[
+      API_KEY
+      GITHUB_TOKEN
+      SECURE_KEYS_FIREBASE_TOKEN
+      SECURE_KEYS_IDENTIFIER
+      SECURE_KEYS_DELIMITER
+      CUSTOM_SECRET_LIST
+    ].each { |key| ENV.delete(key) }
+  end
+
+  it('fetches exact environment variable names') do
+    ENV['CUSTOM_SECRET_LIST'] = 'apiKey,github-token'
+
+    expect(environment.fetch(key: 'CUSTOM_SECRET_LIST')).to(eq('apiKey,github-token'))
+  end
+
+  it('fetches normalized secret keys') do
+    ENV['GITHUB_TOKEN'] = 'github-token-value'
+
+    expect(environment.fetch(key: 'github-token')).to(eq('github-token-value'))
+  end
+
+  it('fetches secure keys prefixed normalized secret keys') do
+    ENV['SECURE_KEYS_FIREBASE_TOKEN'] = 'firebase-token-value'
+
+    expect(environment.fetch(key: 'firebase-token')).to(eq('firebase-token-value'))
+  end
+
+  it('allows inline identifier values for documented CI usage') do
+    ENV['SECURE_KEYS_IDENTIFIER'] = 'github-token,api_key'
+
+    expect(environment.fetch(key: 'github-token,api_key')).to(eq('github-token,api_key'))
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 $LOAD_PATH << './lib'
 require 'bundler/setup'
 require 'core/utils/extensions/kernel'
+require 'core/console/logger'
 require_relative 'helpers/simplecov_env'
 require_relative 'helpers/arguments/handler'
 
@@ -10,5 +11,10 @@ RSpec.configure do |rspec|
   rspec.expect_with :rspec do |config|
     # Remove the max formatted output length
     config.max_formatted_output_length = nil
+  end
+
+  rspec.before(:suite) do
+    null_logger = Logger.new(File::NULL)
+    SecureKeys::Core::Console::Logger.instance_variable_set(:@log, null_logger)
   end
 end

--- a/spec/validation/console/arguments/parser_spec.rb
+++ b/spec/validation/console/arguments/parser_spec.rb
@@ -1,0 +1,43 @@
+require 'validation/console/arguments/parser'
+
+describe(SecureKeys::Validation::Console::Argument::Parser) do
+  # MARK: Help
+
+  it('should be the validate help information from terminal output') do
+    # given
+    expected_help = [
+      'Usage: secure-keys validate [subcommand] [--options]',
+      '',
+      '-h, --help                       Show help for the validate command',
+      '',
+      'Subcommands:',
+      'scan [path]   Scan a directory or staged git changes for exposed secrets',
+      '',
+      'Examples:',
+      'secure-keys validate scan',
+      'secure-keys validate scan ./src',
+      'secure-keys validate scan --staged',
+      'secure-keys validate scan --output report.json'
+    ]
+
+    # when
+    %w[-h --help].each do |option|
+      output_lines = `./bin/secure-keys validate #{option}`.split("\n")
+                                                           .map(&:strip)
+
+      # then
+      expect(output_lines).to(eq(expected_help))
+    end
+  end
+
+  # MARK: Unknown subcommand
+
+  it('should exit with code 1 for an unknown validate subcommand') do
+    # when
+    `./bin/secure-keys validate unknown 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(1))
+  end
+end

--- a/spec/validation/console/arguments/scan/parser_spec.rb
+++ b/spec/validation/console/arguments/scan/parser_spec.rb
@@ -1,0 +1,183 @@
+require 'tmpdir'
+require 'fileutils'
+require 'json'
+require 'validation/console/arguments/scan/parser'
+
+describe(SecureKeys::Validation::Console::Argument::Scan::Parser) do
+  let(:temp_dir) { Dir.mktmpdir('secure_keys_scan_parser_spec') }
+
+  after(:each) do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  # Write a fixture file inside the temp directory and return its path
+  def write_fixture(name:, content:)
+    path = File.join(temp_dir, name)
+    FileUtils.mkdir_p(File.dirname(path))
+    File.write(path, content)
+    path
+  end
+
+  # MARK: Help
+
+  it('should be the scan help information from terminal output') do
+    # given
+    expected_help = [
+      'Usage: secure-keys validate scan [path] [--options]',
+      '',
+      '-h, --help                       Show help for the scan subcommand',
+      '--staged                     Scan staged git changes instead of a directory (default: false)',
+      '-o, --output FILE                Save the scan report as JSON to FILE',
+      '--extensions EXTENSIONS      Comma-separated file extensions to scan (e.g. .rb,.swift)',
+      '--excludes EXCLUDES          Comma-separated directory names to exclude from the scan',
+      '--verbose                    Enable verbose output (default: false)'
+    ]
+
+    # when
+    %w[-h --help].each do |option|
+      output_lines = `./bin/secure-keys validate scan #{option}`.split("\n")
+                                                                .map(&:strip)
+
+      # then
+      expect(output_lines).to(eq(expected_help))
+    end
+  end
+
+  # MARK: Exit codes
+
+  it('should exit with code 0 when no secrets are found') do
+    # given
+    write_fixture(name: 'clean.rb', content: "puts 'hello world'\n")
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(0))
+  end
+
+  it('should exit with code 1 when secrets are detected') do
+    # given
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(1))
+  end
+
+  # MARK: Path argument
+
+  it('should scan the default path (.) when no path is given') do
+    # when
+    output = `./bin/secure-keys validate scan 2>&1`
+
+    # then
+    expect(output).to(include('Scanning directory: .'))
+  end
+
+  it('should scan a custom path passed as a positional argument') do
+    # when
+    output = `./bin/secure-keys validate scan #{temp_dir} 2>&1`
+
+    # then
+    expect(output).to(include("Scanning directory: #{temp_dir}"))
+  end
+
+  # MARK: --extensions
+
+  it('should skip files whose extension is not in --extensions') do
+    # given — secret is in a .rb file; scan is restricted to .swift only
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} --extensions .swift 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(0))
+  end
+
+  it('should scan files whose extension matches --extensions') do
+    # given
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} --extensions .rb 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(1))
+  end
+
+  # MARK: --excludes
+
+  it('should skip directories listed in --excludes') do
+    # given — secret lives inside an excluded subdirectory
+    write_fixture(name: 'vendor/aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} --excludes vendor 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(0))
+  end
+
+  it('should scan directories not listed in --excludes') do
+    # given — secret is NOT inside an excluded directory
+    write_fixture(name: 'src/aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} --excludes vendor 2>&1`
+    exit_code = $CHILD_STATUS.exitstatus
+
+    # then
+    expect(exit_code).to(eq(1))
+  end
+
+  # MARK: --output
+
+  it('should save a JSON report to the path given by --output') do
+    # given
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+    report_path = File.join(temp_dir, 'report.json')
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} --output #{report_path} 2>&1`
+    report = JSON.parse(File.read(report_path))
+
+    # then
+    expect(report).to(include('files_scanned', 'total_findings', 'findings'))
+    expect(report['total_findings']).to(eq(1))
+  end
+
+  it('should include finding details in the JSON report') do
+    # given
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+    report_path = File.join(temp_dir, 'report.json')
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} --output #{report_path} 2>&1`
+    finding = JSON.parse(File.read(report_path))['findings'].first
+
+    # then
+    expect(finding['type']).to(eq('aws_access_key'))
+    expect(finding['severity']).to(eq('critical'))
+  end
+
+  it('should not create a report file when --output is not specified') do
+    # given
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+    report_path = File.join(temp_dir, 'report.json')
+
+    # when
+    `./bin/secure-keys validate scan #{temp_dir} 2>&1`
+
+    # then
+    expect(File.exist?(report_path)).to(be(false))
+  end
+end

--- a/spec/validation/globals/globals_spec.rb
+++ b/spec/validation/globals/globals_spec.rb
@@ -1,0 +1,211 @@
+require 'validation/globals/globals'
+
+describe(SecureKeys::Validation::Globals) do
+  before(:each) do
+    %w[
+      API_KEY_LENGTH SECURE_KEYS_API_KEY_LENGTH
+      TOKEN_LENGTH SECURE_KEYS_TOKEN_LENGTH
+      SECRET_LENGTH SECURE_KEYS_SECRET_LENGTH
+      PASSWORD_LENGTH SECURE_KEYS_PASSWORD_LENGTH
+      KEY_LENGTH SECURE_KEYS_KEY_LENGTH
+      SCAN_EXTENSIONS SECURE_KEYS_SCAN_EXTENSIONS
+      SCAN_EXCLUDES SECURE_KEYS_SCAN_EXCLUDES
+      MAX_SCAN_DEPTH SECURE_KEYS_MAX_SCAN_DEPTH
+      MIN_ENTROPY_THRESHOLD SECURE_KEYS_MIN_ENTROPY_THRESHOLD
+    ].each { |key| ENV.delete(key) }
+  end
+
+  # MARK: Length defaults
+
+  it('should return the default minimum API key length') do
+    # given
+    expected_length = 20
+
+    # when / then
+    expect(described_class.api_key_length).to(eq(expected_length))
+  end
+
+  it('should return the default minimum token length') do
+    # given
+    expected_length = 20
+
+    # when / then
+    expect(described_class.token_length).to(eq(expected_length))
+  end
+
+  it('should return the default minimum secret length') do
+    # given
+    expected_length = 16
+
+    # when / then
+    expect(described_class.secret_length).to(eq(expected_length))
+  end
+
+  it('should return the default minimum password length') do
+    # given
+    expected_length = 12
+
+    # when / then
+    expect(described_class.password_length).to(eq(expected_length))
+  end
+
+  it('should return the default minimum key length') do
+    # given
+    expected_length = 16
+
+    # when / then
+    expect(described_class.key_length).to(eq(expected_length))
+  end
+
+  # MARK: Length env var overrides
+
+  it('should return the API key length from the environment (SECURE_KEYS prefix)') do
+    # given
+    expected_length = 32
+
+    # when
+    ENV['SECURE_KEYS_API_KEY_LENGTH'] = expected_length.to_s
+
+    # then
+    expect(described_class.api_key_length).to(eq(expected_length))
+  end
+
+  it('should return the API key length from the environment (no prefix)') do
+    # given
+    expected_length = 40
+
+    # when
+    ENV['API_KEY_LENGTH'] = expected_length.to_s
+
+    # then
+    expect(described_class.api_key_length).to(eq(expected_length))
+  end
+
+  it('should return the token length from the environment') do
+    # given
+    expected_length = 24
+
+    # when
+    ENV['SECURE_KEYS_TOKEN_LENGTH'] = expected_length.to_s
+
+    # then
+    expect(described_class.token_length).to(eq(expected_length))
+  end
+
+  it('should return the secret length from the environment') do
+    # given
+    expected_length = 24
+
+    # when
+    ENV['SECURE_KEYS_SECRET_LENGTH'] = expected_length.to_s
+
+    # then
+    expect(described_class.secret_length).to(eq(expected_length))
+  end
+
+  it('should return the password length from the environment') do
+    # given
+    expected_length = 20
+
+    # when
+    ENV['SECURE_KEYS_PASSWORD_LENGTH'] = expected_length.to_s
+
+    # then
+    expect(described_class.password_length).to(eq(expected_length))
+  end
+
+  it('should return the key length from the environment') do
+    # given
+    expected_length = 24
+
+    # when
+    ENV['SECURE_KEYS_KEY_LENGTH'] = expected_length.to_s
+
+    # then
+    expect(described_class.key_length).to(eq(expected_length))
+  end
+
+  # MARK: Scan configuration defaults
+
+  it('should return the default file extensions as an array') do
+    # when
+    extensions = described_class.default_scan_extensions
+
+    # then
+    expect(extensions).to(be_a(Array))
+    expect(extensions).to(include('.swift', '.rb', '.py', '.js'))
+    expect(extensions).not_to(be_empty)
+  end
+
+  it('should return the default scan excludes as an array') do
+    # when
+    excludes = described_class.default_scan_excludes
+
+    # then
+    expect(excludes).to(be_a(Array))
+    expect(excludes).to(include('.git', 'node_modules', 'Pods'))
+    expect(excludes).not_to(be_empty)
+  end
+
+  it('should return the default maximum scan depth') do
+    # given
+    expected_depth = 10
+
+    # when / then
+    expect(described_class.max_scan_depth).to(eq(expected_depth))
+  end
+
+  it('should return the default minimum entropy threshold') do
+    # given
+    expected_threshold = 3.0
+
+    # when / then
+    expect(described_class.min_entropy_threshold).to(eq(expected_threshold))
+  end
+
+  # MARK: Scan configuration env var overrides
+
+  it('should return custom scan extensions from the environment') do
+    # given
+    expected_extensions = %w[.rb .go]
+
+    # when
+    ENV['SECURE_KEYS_SCAN_EXTENSIONS'] = expected_extensions.join(',')
+
+    # then
+    expect(described_class.default_scan_extensions).to(eq(expected_extensions))
+  end
+
+  it('should return custom scan excludes from the environment') do
+    # given
+    expected_excludes = %w[vendor tmp]
+
+    # when
+    ENV['SECURE_KEYS_SCAN_EXCLUDES'] = expected_excludes.join(',')
+
+    # then
+    expect(described_class.default_scan_excludes).to(eq(expected_excludes))
+  end
+
+  it('should return a custom maximum scan depth from the environment') do
+    # given
+    expected_depth = 5
+
+    # when
+    ENV['SECURE_KEYS_MAX_SCAN_DEPTH'] = expected_depth.to_s
+
+    # then
+    expect(described_class.max_scan_depth).to(eq(expected_depth))
+  end
+
+  it('should return a custom entropy threshold from the environment') do
+    # given
+    expected_threshold = 4.5
+
+    # when
+    ENV['SECURE_KEYS_MIN_ENTROPY_THRESHOLD'] = expected_threshold.to_s
+
+    # then
+    expect(described_class.min_entropy_threshold).to(eq(expected_threshold))
+  end
+end

--- a/spec/validation/models/finding_spec.rb
+++ b/spec/validation/models/finding_spec.rb
@@ -1,0 +1,130 @@
+require 'validation/models/finding'
+
+describe(SecureKeys::Validation::Finding) do
+  let(:finding) do
+    described_class.new(
+      file: 'lib/config.rb',
+      line: 12,
+      column: 8,
+      type: :github_token,
+      description: 'GitHub Personal Access Token',
+      severity: :high,
+      matched_text: 'ghp_****',
+      full_line: "token = 'ghp_abcdefghijklmnopqrstuvwxyz1234567890'"
+    )
+  end
+
+  let(:addition_finding) do
+    described_class.new(
+      file: 'lib/config.rb',
+      line: 5,
+      column: 0,
+      type: :aws_access_key,
+      description: 'AWS Access Key ID',
+      severity: :critical,
+      matched_text: 'AKIA****',
+      full_line: 'key = "AKIAIOSFODNN7EXAMPLE"',
+      is_addition: true
+    )
+  end
+
+  # MARK: Readers
+
+  it('should expose the file path') do
+    expect(finding.file).to(eq('lib/config.rb'))
+  end
+
+  it('should expose the line number') do
+    expect(finding.line).to(eq(12))
+  end
+
+  it('should expose the column offset') do
+    expect(finding.column).to(eq(8))
+  end
+
+  it('should expose the pattern type') do
+    expect(finding.type).to(eq(:github_token))
+  end
+
+  it('should expose the description') do
+    expect(finding.description).to(eq('GitHub Personal Access Token'))
+  end
+
+  it('should expose the severity') do
+    expect(finding.severity).to(eq(:high))
+  end
+
+  it('should expose the masked matched text') do
+    expect(finding.matched_text).to(eq('ghp_****'))
+  end
+
+  it('should expose the full line') do
+    expect(finding.full_line).to(include('ghp_'))
+  end
+
+  # MARK: addition?
+
+  it('should return false for addition? by default') do
+    expect(finding.addition?).to(eq(false))
+  end
+
+  it('should return true for addition? when is_addition was set to true') do
+    expect(addition_finding.addition?).to(eq(true))
+  end
+
+  # MARK: to_s
+
+  it('should include the file path in the string representation') do
+    expect(finding.to_s).to(include('lib/config.rb'))
+  end
+
+  it('should include the line number in the string representation') do
+    expect(finding.to_s).to(include('12'))
+  end
+
+  it('should include the type in the string representation') do
+    expect(finding.to_s).to(include('github_token'))
+  end
+
+  it('should include the masked text in the string representation') do
+    expect(finding.to_s).to(include('ghp_****'))
+  end
+
+  it('should include a severity icon in the string representation') do
+    expect(finding.to_s).to(include('🟠')) # :high icon
+  end
+
+  it('should include the critical icon for critical severity') do
+    expect(addition_finding.to_s).to(include('🔴'))
+  end
+
+  # MARK: to_h
+
+  it('should return a hash with all expected keys') do
+    hash = finding.to_h
+
+    expect(hash).to(have_key(:file))
+    expect(hash).to(have_key(:line))
+    expect(hash).to(have_key(:column))
+    expect(hash).to(have_key(:type))
+    expect(hash).to(have_key(:description))
+    expect(hash).to(have_key(:severity))
+    expect(hash).to(have_key(:matched_text))
+    expect(hash).to(have_key(:full_line))
+    expect(hash).to(have_key(:is_addition))
+  end
+
+  it('should return the correct values in the hash') do
+    hash = finding.to_h
+
+    expect(hash[:file]).to(eq('lib/config.rb'))
+    expect(hash[:line]).to(eq(12))
+    expect(hash[:type]).to(eq(:github_token))
+    expect(hash[:severity]).to(eq(:high))
+    expect(hash[:is_addition]).to(eq(false))
+  end
+
+  it('should reflect is_addition: true in the hash') do
+    expect(addition_finding.to_h[:is_addition]).to(eq(true))
+  end
+end

--- a/spec/validation/models/scan_result_spec.rb
+++ b/spec/validation/models/scan_result_spec.rb
@@ -1,0 +1,127 @@
+require 'validation/models/finding'
+require 'validation/models/scan_result'
+
+describe(SecureKeys::Validation::ScanResult) do
+  def build_finding(severity: :high)
+    SecureKeys::Validation::Finding.new(
+      file: 'lib/config.rb',
+      line: 1,
+      column: 0,
+      type: :github_token,
+      description: 'GitHub Personal Access Token',
+      severity:,
+      matched_text: 'ghp_****',
+      full_line: "token = 'ghp_abc'"
+    )
+  end
+
+  let(:high_finding)     { build_finding(severity: :high) }
+  let(:critical_finding) { build_finding(severity: :critical) }
+  let(:medium_finding)   { build_finding(severity: :medium) }
+
+  # MARK: Readers
+
+  it('should expose the findings array') do
+    result = described_class.new(findings: [high_finding], files_count: 5)
+    expect(result.findings).to(eq([high_finding]))
+  end
+
+  it('should expose the files count') do
+    result = described_class.new(findings: [], files_count: 10)
+    expect(result.files_count).to(eq(10))
+  end
+
+  # MARK: clean?
+
+  it('should be clean when there are no findings') do
+    result = described_class.new(findings: [], files_count: 3)
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should not be clean when findings are present') do
+    result = described_class.new(findings: [high_finding], files_count: 3)
+    expect(result.clean?).to(eq(false))
+  end
+
+  # MARK: by_severity
+
+  it('should return findings matching the requested severity') do
+    # given
+    result = described_class.new(findings: [high_finding, critical_finding], files_count: 2)
+
+    # when
+    high_findings = result.by_severity(severity: :high)
+
+    # then
+    expect(high_findings.length).to(eq(1))
+    expect(high_findings.first.severity).to(eq(:high))
+  end
+
+  it('should return an empty array when no findings match the requested severity') do
+    result = described_class.new(findings: [high_finding], files_count: 1)
+    expect(result.by_severity(severity: :critical)).to(be_empty)
+  end
+
+  it('should correctly separate findings by severity when multiple severities are present') do
+    # given
+    result = described_class.new(
+      findings: [high_finding, critical_finding, medium_finding],
+      files_count: 3
+    )
+
+    # when / then
+    expect(result.by_severity(severity: :high).length).to(eq(1))
+    expect(result.by_severity(severity: :critical).length).to(eq(1))
+    expect(result.by_severity(severity: :medium).length).to(eq(1))
+    expect(result.by_severity(severity: :low).length).to(eq(0))
+  end
+
+  # MARK: to_h
+
+  it('should return a hash with the expected top-level keys') do
+    result = described_class.new(findings: [high_finding], files_count: 5)
+    hash = result.to_h
+
+    expect(hash).to(have_key(:files_scanned))
+    expect(hash).to(have_key(:total_findings))
+    expect(hash).to(have_key(:by_severity))
+    expect(hash).to(have_key(:findings))
+  end
+
+  it('should reflect the correct file and finding counts in the hash') do
+    # given
+    result = described_class.new(findings: [high_finding, critical_finding], files_count: 7)
+
+    # when
+    hash = result.to_h
+
+    # then
+    expect(hash[:files_scanned]).to(eq(7))
+    expect(hash[:total_findings]).to(eq(2))
+  end
+
+  it('should include severity breakdown counts in the hash') do
+    result = described_class.new(findings: [high_finding, critical_finding], files_count: 2)
+    hash = result.to_h
+
+    expect(hash[:by_severity][:high]).to(eq(1))
+    expect(hash[:by_severity][:critical]).to(eq(1))
+    expect(hash[:by_severity][:medium]).to(eq(0))
+    expect(hash[:by_severity][:low]).to(eq(0))
+  end
+
+  it('should include serialized findings in the hash') do
+    result = described_class.new(findings: [high_finding], files_count: 1)
+    hash = result.to_h
+
+    expect(hash[:findings]).to(be_a(Array))
+    expect(hash[:findings].first).to(have_key(:file))
+    expect(hash[:findings].first).to(have_key(:severity))
+  end
+
+  it('should return an empty findings array in the hash when there are no findings') do
+    result = described_class.new(findings: [], files_count: 5)
+    expect(result.to_h[:findings]).to(be_empty)
+    expect(result.to_h[:total_findings]).to(eq(0))
+  end
+end

--- a/spec/validation/scanner_spec.rb
+++ b/spec/validation/scanner_spec.rb
@@ -1,0 +1,341 @@
+require 'tmpdir'
+require 'fileutils'
+require 'validation/scanner'
+require 'core/console/shell'
+
+describe(SecureKeys::Validation::Scanner) do
+  let(:scanner) { described_class.new }
+
+  let(:temp_dir) { Dir.mktmpdir('secure_keys_scanner_spec') }
+
+  after(:each) do
+    FileUtils.rm_rf(temp_dir)
+  end
+
+  # Write a fixture file and return its path
+  def write_fixture(name:, content:)
+    path = File.join(temp_dir, name)
+    File.write(path, content)
+    path
+  end
+
+  # MARK: Initialization
+
+  it('should initialize with default options') do
+    # when
+    extensions = scanner.send(:file_extensions)
+    excludes   = scanner.send(:exclude_patterns)
+
+    # then
+    expect(extensions).to(include('.swift', '.rb'))
+    expect(excludes).to(include('.git', 'node_modules'))
+  end
+
+  it('should merge custom options over the defaults') do
+    # given
+    custom_scanner = described_class.new(options: { extensions: ['.go'] })
+
+    # when
+    extensions = custom_scanner.send(:file_extensions)
+
+    # then
+    expect(extensions).to(eq(['.go']))
+  end
+
+  # MARK: mask_secret
+
+  it('should return *** for secrets with 6 or fewer characters') do
+    expect(scanner.send(:mask_secret, secret: 'abc')).to(eq('***'))
+    expect(scanner.send(:mask_secret, secret: 'abcdef')).to(eq('***'))
+  end
+
+  it('should show the first 4 characters and mask the rest') do
+    # given
+    secret = 'ghp_abcdefghijklmnop'
+
+    # when
+    masked = scanner.send(:mask_secret, secret:)
+
+    # then
+    expect(masked).to(start_with('ghp_'))
+    expect(masked).to(include('*'))
+    expect(masked.length).to(eq(secret.length))
+  end
+
+  # MARK: scan_directory: clean results
+
+  it('should return a clean result for an empty directory') do
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+    expect(result.files_count).to(eq(0))
+  end
+
+  it('should return a clean result for files with no secrets') do
+    # given
+    write_fixture(name: 'safe.rb', content: "puts 'hello world'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+    expect(result.files_count).to(eq(1))
+  end
+
+  # MARK: scan_directory: pattern detection
+
+  it('should detect a GitHub personal access token in a .rb file') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    write_fixture(name: 'config.rb', content: "token = '#{token}'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(false))
+    github_finding = result.findings.find { |f| f.type == :github_token }
+    expect(github_finding).not_to(be_nil)
+    expect(github_finding.file).to(include('config.rb'))
+    expect(github_finding.line).to(eq(1))
+  end
+
+  it('should detect an AWS access key in a .rb file') do
+    # given
+    write_fixture(name: 'aws.rb', content: "key = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    aws_finding = result.findings.find { |f| f.type == :aws_access_key }
+    expect(aws_finding).not_to(be_nil)
+    expect(aws_finding.severity).to(eq(:critical))
+  end
+
+  it('should detect a Stripe secret key in a .rb file') do
+    # given
+    stripe_key = "sk_live_51H#{'a' * 24}"
+    write_fixture(name: 'payment.rb', content: "key = '#{stripe_key}'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    stripe_finding = result.findings.find { |f| f.type == :stripe_secret_key }
+    expect(stripe_finding).not_to(be_nil)
+  end
+
+  it('should detect a Google Cloud API key in a .swift file') do
+    # given
+    write_fixture(name: 'Config.swift', content: "let apiKey = \"AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe\"\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    gcp_finding = result.findings.find { |f| f.type == :gcp_api_key }
+    expect(gcp_finding).not_to(be_nil)
+  end
+
+  it('should set the correct file path on a finding') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    file_path = write_fixture(name: 'secrets.rb', content: "TOKEN = '#{token}'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.findings.first.file).to(eq(file_path))
+  end
+
+  it('should mask the matched text in findings') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    write_fixture(name: 'config.rb', content: "token = '#{token}'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    finding = result.findings.find { |f| f.type == :github_token }
+    expect(finding.matched_text).to(start_with('ghp_'))
+    expect(finding.matched_text).to(include('*'))
+    expect(finding.matched_text).not_to(include(token))
+  end
+
+  # MARK: scan_directory: line filtering
+
+  it('should skip lines starting with a Ruby comment (#)') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    write_fixture(name: 'config.rb', content: "# token = '#{token}'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should skip lines starting with a Swift comment (//)') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    write_fixture(name: 'Config.swift', content: "// let token = \"#{token}\"\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should skip lines shorter than 10 characters') do
+    # given — "AKIA" alone is only 4 chars, well under the threshold
+    write_fixture(name: 'short.rb', content: "AKIA\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  # MARK: scan_directory: exclusions
+
+  it('should not scan files in excluded directories') do
+    # given
+    excluded_dir = File.join(temp_dir, 'node_modules')
+    FileUtils.mkdir_p(excluded_dir)
+    token = "ghp_#{'a' * 36}"
+    File.write(File.join(excluded_dir, 'secret.rb'), "token = '#{token}'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should not scan files with extensions not in the inclusion list') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    write_fixture(name: 'config.txt', content: "token=#{token}\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should scan multiple files and aggregate findings') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    write_fixture(name: 'file_one.rb', content: "token = '#{token}'\n")
+    write_fixture(name: 'file_two.rb', content: "key   = 'AKIAIOSFODNN7EXAMPLE'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    expect(result.findings.length).to(be >= 2)
+    expect(result.files_count).to(eq(2))
+  end
+
+  # MARK: scan_directory: suspicious assignments
+
+  it('should detect a generic suspicious assignment not covered by specific patterns') do
+    # given — "credential" is not matched by any specific PATTERN keyword,
+    # so check_suspicious_assignments should catch it
+    write_fixture(name: 'config.rb', content: "credential = 'my-internal-service-value-not-a-known-pattern'\n")
+
+    # when
+    result = scanner.scan_directory(path: temp_dir)
+
+    # then
+    suspicious = result.findings.find { |f| f.type == :suspicious_assignment }
+    expect(suspicious).not_to(be_nil)
+    expect(suspicious.severity).to(eq(:low))
+  end
+
+  # MARK: scan_git_diff
+
+  it('should return a clean result when the git diff is empty') do
+    # given
+    allow(SecureKeys::Core::Console::Shell).to(
+      receive(:sh).with(command: 'git diff --cached').and_return(['', nil, nil])
+    )
+
+    # when
+    result = scanner.scan_git_diff
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should detect a secret in a staged git diff addition') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    diff = <<~DIFF
+      diff --git a/lib/config.rb b/lib/config.rb
+      --- a/lib/config.rb
+      +++ b/lib/config.rb
+      @@ -1,0 +1 @@
+      +token = '#{token}'
+    DIFF
+
+    allow(SecureKeys::Core::Console::Shell).to(
+      receive(:sh).with(command: 'git diff --cached').and_return([diff, nil, nil])
+    )
+
+    # when
+    result = scanner.scan_git_diff
+
+    # then
+    expect(result.clean?).to(eq(false))
+    github_finding = result.findings.find { |f| f.type == :github_token }
+    expect(github_finding).not_to(be_nil)
+    expect(github_finding.addition?).to(eq(true))
+  end
+
+  it('should not flag removed lines (starting with -) in a git diff') do
+    # given
+    token = "ghp_#{'a' * 36}"
+    diff = <<~DIFF
+      diff --git a/lib/config.rb b/lib/config.rb
+      --- a/lib/config.rb
+      +++ b/lib/config.rb
+      @@ -1 +0,0 @@
+      -token = '#{token}'
+    DIFF
+
+    allow(SecureKeys::Core::Console::Shell).to(
+      receive(:sh).with(command: 'git diff --cached').and_return([diff, nil, nil])
+    )
+
+    # when
+    result = scanner.scan_git_diff
+
+    # then
+    expect(result.clean?).to(eq(true))
+  end
+
+  it('should scan unstaged changes when staged_only is false') do
+    # given
+    allow(SecureKeys::Core::Console::Shell).to(
+      receive(:sh).with(command: 'git diff').and_return(['', nil, nil])
+    )
+
+    # when
+    result = scanner.scan_git_diff(staged_only: false)
+
+    # then
+    expect(result).not_to(be_nil)
+    expect(result.clean?).to(eq(true))
+  end
+end

--- a/spec/validation/utils/entropy_spec.rb
+++ b/spec/validation/utils/entropy_spec.rb
@@ -1,0 +1,59 @@
+require 'validation/utils/entropy'
+
+describe(SecureKeys::Validation::Entropy) do
+  it('should return 0.0 for an empty string') do
+    # when
+    entropy = described_class.calculate(string: '')
+
+    # then
+    expect(entropy).to(eq(0.0))
+  end
+
+  it('should return 0.0 for a string with a single unique character') do
+    # when
+    entropy = described_class.calculate(string: 'aaaa')
+
+    # then
+    expect(entropy).to(eq(0.0))
+  end
+
+  it('should return 1.0 for a string with two equally distributed characters') do
+    # given — two chars, equal probability each → entropy = 1 bit
+    string = 'ab'
+
+    # when
+    entropy = described_class.calculate(string:)
+
+    # then
+    expect(entropy).to(eq(1.0))
+  end
+
+  it('should return higher entropy for a random-looking string than a repetitive one') do
+    # given
+    repetitive = 'aaabbbccc'
+    random     = 'aB3!xZ9#mQ'
+
+    # when
+    repetitive_entropy = described_class.calculate(string: repetitive)
+    random_entropy     = described_class.calculate(string: random)
+
+    # then
+    expect(random_entropy).to(be > repetitive_entropy)
+  end
+
+  it('should return a Float') do
+    # when
+    result = described_class.calculate(string: 'hello')
+
+    # then
+    expect(result).to(be_a(Float))
+  end
+
+  it('should return positive entropy for a string with mixed characters') do
+    # when
+    entropy = described_class.calculate(string: 'abc123!@#')
+
+    # then
+    expect(entropy).to(be > 0.0)
+  end
+end

--- a/spec/validation/utils/min_length_spec.rb
+++ b/spec/validation/utils/min_length_spec.rb
@@ -1,0 +1,61 @@
+require 'validation/utils/min_length'
+
+describe(SecureKeys::Validation) do
+  subject(:min_lengths) { described_class::MIN_LENGTHS }
+
+  it('should be a Hash') do
+    expect(min_lengths).to(be_a(Hash))
+  end
+
+  it('should be frozen') do
+    expect(min_lengths).to(be_frozen)
+  end
+
+  it('should contain all expected key type entries') do
+    expect(min_lengths).to(have_key(:api_key))
+    expect(min_lengths).to(have_key(:token))
+    expect(min_lengths).to(have_key(:secret))
+    expect(min_lengths).to(have_key(:password))
+    expect(min_lengths).to(have_key(:key))
+  end
+
+  it('should have Integer values for every entry') do
+    min_lengths.each_value do |length|
+      expect(length).to(be_a(Integer))
+    end
+  end
+
+  it('should have positive length values for every entry') do
+    min_lengths.each_value do |length|
+      expect(length).to(be > 0)
+    end
+  end
+
+  it('should set the api_key minimum length to the default') do
+    # given
+    expected_length = SecureKeys::Validation::Globals.api_key_length
+
+    # when / then
+    expect(min_lengths[:api_key]).to(eq(expected_length))
+  end
+
+  it('should set the token minimum length to the default') do
+    expected_length = SecureKeys::Validation::Globals.token_length
+    expect(min_lengths[:token]).to(eq(expected_length))
+  end
+
+  it('should set the secret minimum length to the default') do
+    expected_length = SecureKeys::Validation::Globals.secret_length
+    expect(min_lengths[:secret]).to(eq(expected_length))
+  end
+
+  it('should set the password minimum length to the default') do
+    expected_length = SecureKeys::Validation::Globals.password_length
+    expect(min_lengths[:password]).to(eq(expected_length))
+  end
+
+  it('should set the key minimum length to the default') do
+    expected_length = SecureKeys::Validation::Globals.key_length
+    expect(min_lengths[:key]).to(eq(expected_length))
+  end
+end

--- a/spec/validation/utils/patterns_spec.rb
+++ b/spec/validation/utils/patterns_spec.rb
@@ -1,0 +1,110 @@
+require 'validation/utils/patterns'
+
+describe(SecureKeys::Validation) do
+  subject(:patterns) { described_class::PATTERNS }
+
+  it('should be frozen') do
+    expect(patterns).to(be_frozen)
+  end
+
+  it('should not be empty') do
+    expect(patterns).not_to(be_empty)
+  end
+
+  it('should have required keys on every entry') do
+    patterns.each do |type, config|
+      expect(config.keys).to(include(:pattern, :description, :severity),
+                             "#{type} is missing one or more required keys")
+    end
+  end
+
+  it('should have a Regexp as the :pattern value on every entry') do
+    patterns.each do |type, config|
+      expect(config[:pattern]).to(be_a(Regexp),
+                                  "#{type} :pattern is not a Regexp, got #{config[:pattern].class}")
+    end
+  end
+
+  it('should have a valid severity symbol on every entry') do
+    valid_severities = %i[low medium high critical]
+
+    patterns.each do |type, config|
+      expect(valid_severities).to(include(config[:severity]),
+                                  "#{type} has unknown severity: #{config[:severity]}")
+    end
+  end
+
+  # MARK: Provider-specific pattern smoke tests
+
+  it('should detect a GitHub personal access token') do
+    # given — 36 alphanumeric chars after prefix
+    token = "ghp_#{'a' * 36}"
+
+    # when / then
+    expect(token).to(match(patterns[:github_token][:pattern]))
+  end
+
+  it('should detect a GitHub OAuth access token') do
+    token = "gho_#{'a' * 36}"
+    expect(token).to(match(patterns[:github_oauth][:pattern]))
+  end
+
+  it('should detect a GitHub App token') do
+    token = "ghu_#{'a' * 36}"
+    expect(token).to(match(patterns[:github_app][:pattern]))
+  end
+
+  it('should detect an AWS access key ID') do
+    # given — AKIA followed by 16 uppercase alphanumeric chars
+    key = 'AKIAIOSFODNN7EXAMPLE'
+    expect(key).to(match(patterns[:aws_access_key][:pattern]))
+  end
+
+  it('should detect a Google Cloud API key') do
+    key = 'AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe'
+    expect(key).to(match(patterns[:gcp_api_key][:pattern]))
+  end
+
+  it('should detect a Stripe secret key') do
+    key = "sk_live_51H#{'a' * 24}"
+    expect(key).to(match(patterns[:stripe_secret_key][:pattern]))
+  end
+
+  it('should detect a Stripe test key') do
+    key = "sk_test_51H#{'a' * 24}"
+    expect(key).to(match(patterns[:stripe_secret_key][:pattern]))
+  end
+
+  it('should detect a Slack bot token') do
+    token = "xoxb-123456789012-123456789012-#{'a' * 18}"
+    expect(token).to(match(patterns[:slack_token][:pattern]))
+  end
+
+  it('should detect a JWT token') do
+    token = 'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature'
+    expect(token).to(match(patterns[:jwt_token][:pattern]))
+  end
+
+  it('should detect a PEM private key header') do
+    header = '-----BEGIN PRIVATE KEY-----'
+    expect(header).to(match(patterns[:private_key][:pattern]))
+  end
+
+  it('should detect an RSA private key header') do
+    header = '-----BEGIN RSA PRIVATE KEY-----'
+    expect(header).to(match(patterns[:private_key][:pattern]))
+  end
+
+  it('should detect a SendGrid API key') do
+    key = "SG.#{'a' * 22}.#{'b' * 43}"
+    expect(key).to(match(patterns[:sendgrid_api_key][:pattern]))
+  end
+
+  it('should not match a plain string against a GitHub token pattern') do
+    expect('not_a_token').not_to(match(patterns[:github_token][:pattern]))
+  end
+
+  it('should not match a short string against an AWS access key pattern') do
+    expect('AKIA123').not_to(match(patterns[:aws_access_key][:pattern]))
+  end
+end

--- a/spec/validation/utils/weak_secrets_spec.rb
+++ b/spec/validation/utils/weak_secrets_spec.rb
@@ -1,0 +1,41 @@
+require 'validation/utils/weak_secrets'
+
+describe(SecureKeys::Validation) do
+  subject(:weak_secrets) { described_class::WEAK_SECRETS }
+
+  it('should be an Array') do
+    expect(weak_secrets).to(be_a(Array))
+  end
+
+  it('should be frozen') do
+    expect(weak_secrets).to(be_frozen)
+  end
+
+  it('should not be empty') do
+    expect(weak_secrets).not_to(be_empty)
+  end
+
+  it('should contain common weak passwords') do
+    expect(weak_secrets).to(include('password'))
+    expect(weak_secrets).to(include('secret'))
+    expect(weak_secrets).to(include('123456'))
+  end
+
+  it('should contain common placeholder values') do
+    expect(weak_secrets).to(include('test'))
+    expect(weak_secrets).to(include('demo'))
+    expect(weak_secrets).to(include('example'))
+  end
+
+  it('should contain common default credentials') do
+    expect(weak_secrets).to(include('admin'))
+    expect(weak_secrets).to(include('default'))
+    expect(weak_secrets).to(include('changeme'))
+  end
+
+  it('should contain all String elements') do
+    weak_secrets.each do |entry|
+      expect(entry).to(be_a(String))
+    end
+  end
+end

--- a/spec/validation/validation_issue_spec.rb
+++ b/spec/validation/validation_issue_spec.rb
@@ -1,0 +1,111 @@
+require 'validation/validation_issue'
+
+describe(SecureKeys::Validation::ValidationIssue) do
+  let(:issue) do
+    described_class.new(
+      severity: :warning,
+      type: :too_short,
+      message: 'Key is too short',
+      recommendation: 'Use a longer secret'
+    )
+  end
+
+  let(:issue_without_recommendation) do
+    described_class.new(
+      severity: :info,
+      type: :pattern_detected,
+      message: 'Pattern matched',
+      recommendation: nil
+    )
+  end
+
+  # MARK: Initialization
+
+  it('should expose the severity') do
+    expect(issue.severity).to(eq(:warning))
+  end
+
+  it('should expose the type') do
+    expect(issue.type).to(eq(:too_short))
+  end
+
+  it('should expose the message') do
+    expect(issue.message).to(eq('Key is too short'))
+  end
+
+  it('should expose the recommendation') do
+    expect(issue.recommendation).to(eq('Use a longer secret'))
+  end
+
+  it('should expose a nil recommendation when none was given') do
+    expect(issue_without_recommendation.recommendation).to(be_nil)
+  end
+
+  # MARK: to_s
+
+  it('should include the severity in the string representation') do
+    expect(issue.to_s).to(include('WARNING'))
+  end
+
+  it('should include the message in the string representation') do
+    expect(issue.to_s).to(include('Key is too short'))
+  end
+
+  it('should include the recommendation in the string representation when present') do
+    expect(issue.to_s).to(include('Use a longer secret'))
+  end
+
+  it('should not include a recommendation line when the recommendation is nil') do
+    expect(issue_without_recommendation.to_s).not_to(include('💡'))
+  end
+
+  # MARK: Severity icons
+
+  it('should use the critical icon for critical severity') do
+    # given
+    critical_issue = described_class.new(severity: :critical, type: :t, message: 'm', recommendation: nil)
+
+    # when / then
+    expect(critical_issue.to_s).to(include('🔴'))
+  end
+
+  it('should use the error icon for error severity') do
+    # given
+    error_issue = described_class.new(severity: :error, type: :t, message: 'm', recommendation: nil)
+
+    # when / then
+    expect(error_issue.to_s).to(include('❌'))
+  end
+
+  it('should use the warning icon for warning severity') do
+    expect(issue.to_s).to(include('⚠️'))
+  end
+
+  it('should use the info icon for info severity') do
+    expect(issue_without_recommendation.to_s).to(include('ℹ️'))
+  end
+
+  # MARK: to_h
+
+  it('should return a hash with all expected keys') do
+    # when
+    hash = issue.to_h
+
+    # then
+    expect(hash).to(have_key(:severity))
+    expect(hash).to(have_key(:type))
+    expect(hash).to(have_key(:message))
+    expect(hash).to(have_key(:recommendation))
+  end
+
+  it('should return the correct values in the hash') do
+    # when
+    hash = issue.to_h
+
+    # then
+    expect(hash[:severity]).to(eq(:warning))
+    expect(hash[:type]).to(eq(:too_short))
+    expect(hash[:message]).to(eq('Key is too short'))
+    expect(hash[:recommendation]).to(eq('Use a longer secret'))
+  end
+end

--- a/spec/validation/validation_result_spec.rb
+++ b/spec/validation/validation_result_spec.rb
@@ -1,0 +1,192 @@
+require 'validation/validation_result'
+require 'validation/validation_issue'
+
+describe(SecureKeys::Validation::ValidationResult) do
+  let(:critical_issue) do
+    SecureKeys::Validation::ValidationIssue.new(
+      severity: :critical,
+      type: :weak_secret,
+      message: 'Weak secret detected',
+      recommendation: 'Use a stronger secret'
+    )
+  end
+
+  let(:error_issue) do
+    SecureKeys::Validation::ValidationIssue.new(
+      severity: :error,
+      type: :empty_value,
+      message: 'Value is empty',
+      recommendation: 'Provide a non-empty value'
+    )
+  end
+
+  let(:warning_issue) do
+    SecureKeys::Validation::ValidationIssue.new(
+      severity: :warning,
+      type: :too_short,
+      message: 'Value is too short',
+      recommendation: 'Use a longer value'
+    )
+  end
+
+  let(:detected_type) do
+    { type: :github_token, description: 'GitHub Personal Access Token', severity: :high }
+  end
+
+  def build_result(issues: [], detected_type: nil)
+    described_class.new(key: :api_key, value: 'some_value', issues:, detected_type:)
+  end
+
+  # MARK: valid?
+
+  it('should be valid when there are no issues') do
+    result = build_result
+    expect(result.valid?).to(eq(true))
+  end
+
+  it('should not be valid when there is a critical issue') do
+    result = build_result(issues: [critical_issue])
+    expect(result.valid?).to(eq(false))
+  end
+
+  it('should not be valid when there is an error issue') do
+    result = build_result(issues: [error_issue])
+    expect(result.valid?).to(eq(false))
+  end
+
+  it('should be valid when there are only warnings') do
+    result = build_result(issues: [warning_issue])
+    expect(result.valid?).to(eq(true))
+  end
+
+  # MARK: critical? / errors? / warnings?
+
+  it('should return true for critical? when a critical issue is present') do
+    result = build_result(issues: [critical_issue])
+    expect(result.critical?).to(eq(true))
+  end
+
+  it('should return false for critical? when no critical issue is present') do
+    result = build_result(issues: [error_issue])
+    expect(result.critical?).to(eq(false))
+  end
+
+  it('should return true for errors? when an error issue is present') do
+    result = build_result(issues: [error_issue])
+    expect(result.errors?).to(eq(true))
+  end
+
+  it('should return false for errors? when no error issue is present') do
+    result = build_result(issues: [warning_issue])
+    expect(result.errors?).to(eq(false))
+  end
+
+  it('should return true for warnings? when a warning issue is present') do
+    result = build_result(issues: [warning_issue])
+    expect(result.warnings?).to(eq(true))
+  end
+
+  it('should return false for warnings? when no warning issue is present') do
+    result = build_result
+    expect(result.warnings?).to(eq(false))
+  end
+
+  # MARK: severity_level
+
+  it('should return :ok when there are no issues') do
+    expect(build_result.severity_level).to(eq(:ok))
+  end
+
+  it('should return :warning when only warnings are present') do
+    expect(build_result(issues: [warning_issue]).severity_level).to(eq(:warning))
+  end
+
+  it('should return :error when an error is present') do
+    expect(build_result(issues: [error_issue]).severity_level).to(eq(:error))
+  end
+
+  it('should return :critical when a critical issue is present') do
+    expect(build_result(issues: [critical_issue]).severity_level).to(eq(:critical))
+  end
+
+  it('should return :critical when both critical and error issues are present') do
+    result = build_result(issues: [critical_issue, error_issue])
+    expect(result.severity_level).to(eq(:critical))
+  end
+
+  # MARK: summary
+
+  it('should include a pass indicator in the summary when valid') do
+    result = build_result
+    expect(result.summary).to(include('✅'))
+  end
+
+  it('should include the key name in the summary') do
+    result = build_result
+    expect(result.summary).to(include('api_key'))
+  end
+
+  it('should include the issue count in the summary when invalid') do
+    # given
+    result = build_result(issues: [critical_issue, warning_issue])
+
+    # when
+    summary = result.summary
+
+    # then
+    expect(summary).to(include('2'))
+  end
+
+  # MARK: detected_type
+
+  it('should expose the detected type when provided') do
+    result = build_result(detected_type:)
+    expect(result.detected_type).to(eq(detected_type))
+  end
+
+  it('should expose nil when no detected type was provided') do
+    result = build_result
+    expect(result.detected_type).to(be_nil)
+  end
+
+  # MARK: to_h
+
+  it('should return a hash with the expected top-level keys') do
+    # when
+    hash = build_result(issues: [warning_issue]).to_h
+
+    # then
+    expect(hash).to(have_key(:key))
+    expect(hash).to(have_key(:valid))
+    expect(hash).to(have_key(:severity))
+    expect(hash).to(have_key(:detected_type))
+    expect(hash).to(have_key(:issues))
+  end
+
+  it('should reflect the correct valid flag in the hash') do
+    expect(build_result.to_h[:valid]).to(eq(true))
+    expect(build_result(issues: [error_issue]).to_h[:valid]).to(eq(false))
+  end
+
+  it('should include serialized issues in the hash') do
+    # when
+    hash = build_result(issues: [warning_issue]).to_h
+
+    # then
+    expect(hash[:issues]).to(be_a(Array))
+    expect(hash[:issues].first).to(have_key(:severity))
+    expect(hash[:issues].first).to(have_key(:message))
+  end
+
+  # MARK: print
+
+  it('should not raise when printing a valid result') do
+    result = build_result
+    expect { result.print }.not_to(raise_error)
+  end
+
+  it('should not raise when printing an invalid result with detected type') do
+    result = build_result(issues: [critical_issue], detected_type:)
+    expect { result.print }.not_to(raise_error)
+  end
+end

--- a/spec/validation/validator_spec.rb
+++ b/spec/validation/validator_spec.rb
@@ -1,0 +1,277 @@
+require 'validation/validator'
+
+describe(SecureKeys::Validation::Validator) do
+  let(:validator) { described_class.new }
+
+  # MARK: validate: empty value
+
+  it('should return an error issue when the value is empty') do
+    # when
+    result = validator.validate(key: :api_key, value: '')
+
+    # then
+    expect(result.errors?).to(eq(true))
+    expect(result.valid?).to(eq(false))
+  end
+
+  it('should return an error issue when the value is nil-like (empty string)') do
+    # when
+    result = validator.validate(key: :myToken, value: '')
+
+    # then
+    issue = result.issues.find { |i| i.type == :empty_value }
+    expect(issue).not_to(be_nil)
+    expect(issue.severity).to(eq(:error))
+  end
+
+  # MARK: validate: weak secret
+
+  it('should return a critical issue for a common weak value') do
+    # when
+    result = validator.validate(key: :apiKey, value: 'password')
+
+    # then
+    expect(result.critical?).to(eq(true))
+    issue = result.issues.find { |i| i.type == :weak_secret }
+    expect(issue).not_to(be_nil)
+  end
+
+  it('should return a critical issue when the value contains a weak substring') do
+    # when
+    result = validator.validate(key: :apiKey, value: 'password123')
+
+    # then
+    expect(result.critical?).to(eq(true))
+  end
+
+  it('should return a critical issue for the placeholder value "test"') do
+    # when
+    result = validator.validate(key: :mySecret, value: 'test')
+
+    # then
+    expect(result.critical?).to(eq(true))
+  end
+
+  # MARK: validate: minimum length
+
+  it('should return a warning when the value is shorter than the minimum for its type') do
+    # given — api_key minimum is 20 chars
+    result = validator.validate(key: :api_key, value: 'short')
+
+    # then
+    expect(result.warnings?).to(eq(true))
+    issue = result.issues.find { |i| i.type == :too_short }
+    expect(issue).not_to(be_nil)
+    expect(issue.severity).to(eq(:warning))
+  end
+
+  it('should infer api_key type for a key name containing "api" and "key"') do
+    # given — api_key minimum is 20 chars; value is 5 chars
+    result = validator.validate(key: :my_api_key, value: 'short')
+
+    # then
+    expect(result.warnings?).to(eq(true))
+  end
+
+  it('should infer token type for a key name containing "token"') do
+    # given — token minimum is 20 chars; value is 5 chars
+    result = validator.validate(key: :githubToken, value: 'short')
+
+    # then
+    expect(result.warnings?).to(eq(true))
+  end
+
+  it('should infer password type for a key name containing "password"') do
+    # given — password minimum is 12 chars; value is 5 chars
+    result = validator.validate(key: :adminPassword, value: 'short')
+
+    # then
+    expect(result.warnings?).to(eq(true))
+  end
+
+  # MARK: validate: good value
+
+  it('should be valid for a long, non-weak, non-patterned value') do
+    # given
+    value = 'a_very_long_and_unpredictable_api_key_that_is_definitely_fine_123'
+
+    # when
+    result = validator.validate(key: :api_key, value:)
+
+    # then
+    expect(result.valid?).to(eq(true))
+    expect(result.severity_level).to(eq(:ok))
+  end
+
+  it('should produce no issues for a strong value') do
+    # given
+    value = 'a_very_long_and_unpredictable_api_key_that_is_definitely_fine_123'
+
+    # when
+    result = validator.validate(key: :api_key, value:)
+
+    # then
+    expect(result.issues).to(be_empty)
+  end
+
+  # MARK: validate: production key detection
+
+  it('should return a critical issue for a live Stripe key when production is not allowed') do
+    # given
+    stripe_key = "sk_live_51H#{'a' * 24}"
+
+    # when
+    result = validator.validate(key: :stripeKey, value: stripe_key)
+
+    # then
+    expect(result.critical?).to(eq(true))
+    issue = result.issues.find { |i| i.type == :production_key_detected }
+    expect(issue).not_to(be_nil)
+  end
+
+  it('should not flag a critical pattern when allow_production option is true') do
+    # given
+    stripe_key = "sk_live_51H#{'a' * 24}"
+
+    # when
+    result = validator.validate(key: :stripeKey, value: stripe_key, options: { allow_production: true })
+
+    # then
+    production_issue = result.issues.find { |i| i.type == :production_key_detected }
+    expect(production_issue).to(be_nil)
+  end
+
+  it('should emit an informational issue when warn_on_pattern option is true') do
+    # given — publishable key is :medium severity, so it won't hit the critical path
+    stripe_publishable_key = "pk_test_51H#{'a' * 24}"
+
+    # when
+    result = validator.validate(key: :stripeKey, value: stripe_publishable_key, options: { warn_on_pattern: true })
+
+    # then
+    pattern_issue = result.issues.find { |i| i.type == :pattern_detected }
+    expect(pattern_issue).not_to(be_nil)
+    expect(pattern_issue.severity).to(eq(:info))
+  end
+
+  # MARK: validate: entropy check
+
+  it('should return a warning for a low-entropy value when check_entropy is enabled') do
+    # given — 'aaaaaaaaaaaaaaaaaaaaaa' is long but has zero entropy
+    result = validator.validate(
+      key: :api_key,
+      value: 'a' * 30,
+      options: { check_entropy: true }
+    )
+
+    # then
+    entropy_issue = result.issues.find { |i| i.type == :low_entropy }
+    expect(entropy_issue).not_to(be_nil)
+  end
+
+  it('should not check entropy when the option is not set') do
+    # given
+    result = validator.validate(key: :api_key, value: 'a' * 30)
+
+    # then
+    entropy_issue = result.issues.find { |i| i.type == :low_entropy }
+    expect(entropy_issue).to(be_nil)
+  end
+
+  # MARK: detect_type
+
+  it('should return nil when no pattern matches') do
+    expect(validator.detect_type(value: 'not-a-secret')).to(be_nil)
+  end
+
+  it('should detect a GitHub personal access token') do
+    # given — 36 alphanumeric chars after prefix
+    token = "ghp_#{'a' * 36}"
+
+    # when
+    result = validator.detect_type(value: token)
+
+    # then
+    expect(result).not_to(be_nil)
+    expect(result[:type]).to(eq(:github_token))
+  end
+
+  it('should detect an AWS access key') do
+    # given
+    key = 'AKIAIOSFODNN7EXAMPLE'
+
+    # when
+    result = validator.detect_type(value: key)
+
+    # then
+    expect(result).not_to(be_nil)
+    expect(result[:type]).to(eq(:aws_access_key))
+  end
+
+  it('should detect a Stripe secret key') do
+    # given
+    key = "sk_live_51H#{'a' * 24}"
+
+    # when
+    result = validator.detect_type(value: key)
+
+    # then
+    expect(result).not_to(be_nil)
+    expect(result[:type]).to(eq(:stripe_secret_key))
+  end
+
+  it('should detect a Google Cloud API key') do
+    result = validator.detect_type(value: 'AIzaSyDaGmWKa4JsXZ-HjGw7ISLn_3namBGewQe')
+    expect(result[:type]).to(eq(:gcp_api_key))
+  end
+
+  it('should include the :type key in the detect_type result') do
+    result = validator.detect_type(value: 'AKIAIOSFODNN7EXAMPLE')
+    expect(result).to(have_key(:type))
+    expect(result).to(have_key(:description))
+    expect(result).to(have_key(:severity))
+  end
+
+  # MARK: recommendations
+
+  it('should return GitHub recommendations for a key named githubToken') do
+    # when
+    recs = validator.recommendations(key: :githubToken)
+
+    # then
+    expect(recs).not_to(be_empty)
+    expect(recs.any? { |r| r.downcase.include?('github') }).to(eq(true))
+  end
+
+  it('should return AWS recommendations for a key named awsAccessKey') do
+    # when
+    recs = validator.recommendations(key: :awsAccessKey)
+
+    # then
+    expect(recs).not_to(be_empty)
+    expect(recs.any? { |r| r.downcase.include?('aws') }).to(eq(true))
+  end
+
+  it('should return Stripe recommendations for a key named stripeSecretKey') do
+    # when
+    recs = validator.recommendations(key: :stripeSecretKey)
+
+    # then
+    expect(recs).not_to(be_empty)
+    expect(recs.any? { |r| r.downcase.include?('stripe') }).to(eq(true))
+  end
+
+  it('should return generic rotation recommendations for a key named apiKey') do
+    # when
+    recs = validator.recommendations(key: :apiKey)
+
+    # then
+    expect(recs).not_to(be_empty)
+    expect(recs.any? { |r| r.downcase.include?('rotat') }).to(eq(true))
+  end
+
+  it('should return an empty array for a key name with no recognizable provider or type') do
+    # given — no "github", "aws", "stripe", "api", or "key" substring
+    expect(validator.recommendations(key: :databaseHost)).to(be_empty)
+  end
+end


### PR DESCRIPTION
### Description

This PR introduces a **Secret Scanning and Validation** feature to `secure-keys`, adding both a Ruby API and a `validate scan` CLI subcommand that detect accidentally exposed credentials in source files or git diffs.

**Why this change is needed**

Developers using `secure-keys` to manage secrets in iOS projects still face the risk of accidentally committing raw credential values in source files or configuration scripts. This feature closes that gap by providing a scanner that can be run locally, in CI, or as a pre-commit hook to catch leaks before they reach a repository.

**What was added**

- **`SecureKeys::Validation::Scanner`** — scans a directory or a `git diff` for 25+ known secret patterns (AWS, GitHub, GCP, Stripe, Slack, JWT, SendGrid, and more). Returns a `ScanResult` with per-severity breakdowns and `to_h` serialization for JSON export.
- **`SecureKeys::Validation::Validator`** — validates a single secret value against configurable rules (minimum length, entropy, production-key detection, pattern matching). Returns a `ValidationResult` with a severity level and a formatted summary.
- **`secure-keys validate scan` CLI** — a new positional subcommand routed through the existing `Core::Console::Argument::Parser` via a `SUBCOMMANDS` dispatch table, keeping `keys.rb` untouched.
  - Supports `[path]`, `--staged`, `--output FILE`, `--extensions`, `--excludes`, and `--verbose`.
  - Exits `0` when the scan is clean, `1` when findings are present — suitable as a pre-commit or CI step.
- **`Core::Console::Argument::Fetchable`** — a shared mixin that provides `fetch` and `set` class methods to both `Core::Console::Argument::Handler` and `Validation::Console::Argument::Scan::Handler`, eliminating duplicated argument-resolution logic.
- **`Services::Environment`** — a stateless utility module for reading environment variables with `SECURE_KEYS_` prefix support and typed accessors (e.g. `integer`).
- Full test coverage across all new classes and the CLI layer (259 examples, 0 failures).
- Updated `README.md` and `docs/index.md` with the complete CLI reference, Ruby API usage, detected-pattern table, and environment variable configuration table.

### Medias (if needed)

N/A

### Testplan

- [x] I tested this change on my local environment.
- [x] I ran the unit tests.

**Detailed steps to test the changes (if applicable):**

```bash
# Install dependencies
bundle install

# Run the full test suite
bundle exec rspec

# Scan the current directory for exposed secrets
bundle exec ./bin/secure-keys validate scan

# Scan only staged git changes (pre-commit hook usage)
bundle exec ./bin/secure-keys validate scan --staged

# Scan a specific path and save a JSON report
bundle exec ./bin/secure-keys validate scan ./src --output report.json

# Restrict the scan to specific file types and exclude a directory
bundle exec ./bin/secure-keys validate scan --extensions .rb,.swift --excludes vendor
```

### Checklist

- [x] I added tests for this change.
- [x] I checked the code style and run the linter.
- [x] I added necessary documentation (if applicable).
